### PR TITLE
feat(ai): la IA tiene en cuenta señas del compañero en Grande, Chica y Juego con mano

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -663,17 +663,35 @@ class AILogic constructor(
             if (gesturer.team == aiPlayer.team && gesturer.id != aiPlayer.id) {
                 val gestureName = gestureIdToName(gesture.gestureResId)
                 logBuilder.appendLine("   - (Offensive) Partner ${gesturer.name} has '$gestureName'. Merging strength.")
+                val gesturerIsMano = gameState.manoPlayerId == gesturer.id
 
-                // --- LÓGICA DE FUSIÓN CORREGIDA ---
+                // Cada seña del compañero implica info parcial sobre Grande y Chica además
+                // de la jugada concreta. Aplicamos un boost moderado al lance que cuadra:
+                // las 2 cartas que no vemos podrían tirar la jugada del compañero, por eso
+                // no asumimos el máximo.
+                val grandeBoost = partnerGrandeBoost(gesture.gestureResId)
+                val chicaBoost = partnerChicaBoost(gesture.gestureResId)
+                if (grandeBoost > teamStrength.grande) {
+                    teamStrength = teamStrength.copy(grande = grandeBoost)
+                    logBuilder.appendLine("     -> Partner gesture boosts Grande to $grandeBoost.")
+                }
+                if (chicaBoost > teamStrength.chica) {
+                    teamStrength = teamStrength.copy(chica = chicaBoost)
+                    logBuilder.appendLine("     -> Partner gesture boosts Chica to $chicaBoost.")
+                }
+
                 when (val meaning = getGestureMeaning(gesture.gestureResId)) {
                     is GestureMeaning.Pares -> {
-                        val gestureStrength = getParesPlayStrength(meaning.play, false) // Calcula la fuerza de la seña
+                        val gestureStrength = getParesPlayStrength(meaning.play, gesturerIsMano)
                         teamStrength = teamStrength.copy(pares = max(teamStrength.pares, gestureStrength))
-                        logBuilder.appendLine("     -> Partner Pares Strength is ~$gestureStrength. Team Pares Strength is now ${teamStrength.pares}.")
+                        logBuilder.appendLine("     -> Partner Pares Strength is ~$gestureStrength (mano=$gesturerIsMano). Team Pares Strength is now ${teamStrength.pares}.")
                     }
                     is GestureMeaning.Juego -> {
-                        teamStrength = teamStrength.copy(juego = max(teamStrength.juego, 100))
-                        logBuilder.appendLine("     -> Partner Juego Strength is 100. Team Juego Strength is now ${teamStrength.juego}.")
+                        // 31 sin ser mano puede perder ante otro 31 más cerca de mano:
+                        // mismo trato que para la propia mano en evaluateHand.
+                        val juegoStrength = if (gesturerIsMano) 100 else 85
+                        teamStrength = teamStrength.copy(juego = max(teamStrength.juego, juegoStrength))
+                        logBuilder.appendLine("     -> Partner Juego Strength is $juegoStrength (mano=$gesturerIsMano). Team Juego Strength is now ${teamStrength.juego}.")
                     }
                     else -> {}
                 }
@@ -723,6 +741,25 @@ class AILogic constructor(
             logBuilder.appendLine("   -> Strength not adjusted by gestures.")
         }
         return finalAdjustedStrength
+    }
+
+    // Boost al lance Grande del equipo según la seña del compañero.
+    // Estimación moderada: una seña fija 2 cartas pero deja otras 2 desconocidas
+    // que podrían rebajar la jugada real para Grande.
+    internal fun partnerGrandeBoost(gestureResId: Int): Int = when (gestureResId) {
+        R.drawable.reyes_3 -> 90   // 3 Reyes/Treses → dispara Envido seguro (>80)
+        R.drawable.sena_31 -> 70   // 31 implica figuras pero no necesariamente Reyes
+        R.drawable.reyes_2 -> 65   // par alto: activa bluff y empuja a Envido si ya tienes algo
+        R.drawable.duples_altos -> 50  // info parcial: por sí sola no dispara, pero suma con la propia
+        else -> 0
+    }
+
+    // Boost al lance Chica del equipo según la seña del compañero.
+    internal fun partnerChicaBoost(gestureResId: Int): Int = when (gestureResId) {
+        R.drawable.ases_3 -> 90    // 3 Ases/Doses → dispara Envido seguro
+        R.drawable.ases_2 -> 65    // par bajo
+        R.drawable.duples_bajos -> 50
+        else -> 0
     }
 
     private fun getParesPlayStrength(paresPlay: ParesPlay, isMano: Boolean): Int {

--- a/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
+++ b/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
@@ -344,4 +344,58 @@ class AILogicTest {
 
         assertFalse("Con marcador igualado no debe cantar órdago proactivo", decision.action is GameAction.Órdago)
     }
+
+    // --- TESTS DE REGRESIÓN: SEÑAS DEL COMPAÑERO ---
+
+    @Test
+    fun `partnerGrandeBoost - reyes_3 is the strongest grande boost`() {
+        assertEquals(90, aiLogic.partnerGrandeBoost(com.doselfurioso.musvisto.R.drawable.reyes_3))
+    }
+
+    @Test
+    fun `partnerGrandeBoost - sena_31 implies figures, gets moderate boost`() {
+        assertEquals(70, aiLogic.partnerGrandeBoost(com.doselfurioso.musvisto.R.drawable.sena_31))
+    }
+
+    @Test
+    fun `partnerGrandeBoost - reyes_2 gets medium boost`() {
+        assertEquals(65, aiLogic.partnerGrandeBoost(com.doselfurioso.musvisto.R.drawable.reyes_2))
+    }
+
+    @Test
+    fun `partnerGrandeBoost - duples_altos gets low boost`() {
+        assertEquals(50, aiLogic.partnerGrandeBoost(com.doselfurioso.musvisto.R.drawable.duples_altos))
+    }
+
+    @Test
+    fun `partnerGrandeBoost - chica-only and ciega gestures give zero grande boost`() {
+        assertEquals(0, aiLogic.partnerGrandeBoost(com.doselfurioso.musvisto.R.drawable.ases_2))
+        assertEquals(0, aiLogic.partnerGrandeBoost(com.doselfurioso.musvisto.R.drawable.ases_3))
+        assertEquals(0, aiLogic.partnerGrandeBoost(com.doselfurioso.musvisto.R.drawable.duples_bajos))
+        assertEquals(0, aiLogic.partnerGrandeBoost(com.doselfurioso.musvisto.R.drawable.ciega))
+    }
+
+    @Test
+    fun `partnerChicaBoost - ases_3 is the strongest chica boost`() {
+        assertEquals(90, aiLogic.partnerChicaBoost(com.doselfurioso.musvisto.R.drawable.ases_3))
+    }
+
+    @Test
+    fun `partnerChicaBoost - ases_2 gets medium boost`() {
+        assertEquals(65, aiLogic.partnerChicaBoost(com.doselfurioso.musvisto.R.drawable.ases_2))
+    }
+
+    @Test
+    fun `partnerChicaBoost - duples_bajos gets low boost`() {
+        assertEquals(50, aiLogic.partnerChicaBoost(com.doselfurioso.musvisto.R.drawable.duples_bajos))
+    }
+
+    @Test
+    fun `partnerChicaBoost - grande-only and ciega gestures give zero chica boost`() {
+        assertEquals(0, aiLogic.partnerChicaBoost(com.doselfurioso.musvisto.R.drawable.reyes_2))
+        assertEquals(0, aiLogic.partnerChicaBoost(com.doselfurioso.musvisto.R.drawable.reyes_3))
+        assertEquals(0, aiLogic.partnerChicaBoost(com.doselfurioso.musvisto.R.drawable.duples_altos))
+        assertEquals(0, aiLogic.partnerChicaBoost(com.doselfurioso.musvisto.R.drawable.sena_31))
+        assertEquals(0, aiLogic.partnerChicaBoost(com.doselfurioso.musvisto.R.drawable.ciega))
+    }
 }


### PR DESCRIPTION
> ⚠️ **Depende de #9** (`feature/ai-envite-improvements`). Mergear primero ese; este PR auto-rebasará a master.

## Summary
Extiende `adjustStrengthsBasedOnKnownGestures` para que las señas del compañero aporten también a Grande y Chica, no solo a Pares/Juego:

- **Boosts nuevos** al `teamStrength` según la seña del compañero:
  - `reyes_3` / `ases_3`: 90 (dispara Envido seguro >80).
  - `sena_31`: 70.
  - `reyes_2` / `ases_2`: 65 (activa bluff envido).
  - `duples_altos` / `duples_bajos`: 50 (suma solo si tu propia mano ya rondaba 60+).
- **31 del compañero mano-aware**: si el compañero que tiene 31 es mano se mantiene en 100, si no es mano baja a 85 (un 31 fuera de mano puede perder contra otro 31 más cerca de mano — refleja la misma penalización que la propia mano ya tenía en `evaluateHand`).
- **`getParesPlayStrength`** recibe ahora el `isMano` correcto del compañero (antes hardcoded a `false`).

Helpers `partnerGrandeBoost` y `partnerChicaBoost` expuestos como `internal` para tests unitarios directos.

## Test plan
- [x] Tests JUnit pasan (9 nuevos cubren los mapeos).
- [ ] Probar en simulador: con compañero que pasa seña, verificar que la IA juega más agresiva en el lance correspondiente.