### PR TITLE
feat(debug): mover panel AI Debug a src/debug con stub no-op en release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            // Solo para poder instalar release en dispositivos de desarrollo.
+            // Sustituir por la clave real cuando se publique.
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
     compileOptions {

--- a/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
+++ b/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
@@ -1,0 +1,183 @@
+package com.doselfurioso.musvisto.debug
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.doselfurioso.musvisto.presentation.GameViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Implementación real de las features de debug, solo en builds de tipo `debug`.
+ * El homónimo en `src/release/` es un stub no-op.
+ */
+object DebugFeatures {
+    const val IS_ENABLED = true
+
+    /**
+     * Overlay flotante en la esquina inferior derecha con el log de las últimas
+     * decisiones de la IA. Solo se renderiza si el usuario activó el modo debug
+     * desde el menú de pausa.
+     */
+    @Composable
+    fun AiDebugPanelOverlay(viewModel: GameViewModel) {
+        val isDebugMode by viewModel.isDebugMode.collectAsState()
+        if (!isDebugMode) return
+
+        val logs by viewModel.aiDebugLogs.collectAsState()
+        Box(modifier = Modifier.fillMaxSize()) {
+            AiDebugPanel(
+                logs = logs,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(8.dp)
+            )
+        }
+    }
+
+    /** Botón "🐛 Debug ON/OFF" para incluir dentro del menú de pausa. */
+    @Composable
+    fun DebugToggleButton(viewModel: GameViewModel) {
+        val isDebugMode by viewModel.isDebugMode.collectAsState()
+        Button(
+            onClick = { viewModel.onToggleDebugMode() },
+            colors = ButtonDefaults.buttonColors(
+                containerColor = if (isDebugMode) Color(0xFF00C853) else Color(0xFF424242)
+            )
+        ) {
+            Text(text = if (isDebugMode) "🐛 Debug: ON" else "🐛 Debug: OFF")
+        }
+    }
+}
+
+@Composable
+private fun AiDebugPanel(logs: List<String>, modifier: Modifier = Modifier) {
+    var expanded by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+
+    Column(
+        modifier = modifier.padding(4.dp),
+        horizontalAlignment = Alignment.End
+    ) {
+        Box(
+            modifier = Modifier
+                .background(Color.Black.copy(alpha = 0.75f), RoundedCornerShape(8.dp))
+                .clickable { expanded = !expanded }
+                .padding(horizontal = 10.dp, vertical = 4.dp)
+        ) {
+            Text(
+                text = if (expanded) "▼ AI Log" else "▲ AI Log",
+                color = Color(0xFF00FF88),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+
+        if (expanded) {
+            Row(
+                modifier = Modifier
+                    .width(320.dp)
+                    .padding(vertical = 4.dp),
+                horizontalArrangement = Arrangement.End
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(Color(0xFF1565C0).copy(alpha = 0.9f), RoundedCornerShape(6.dp))
+                        .clickable(enabled = logs.isNotEmpty()) { exportAiDebugLog(context, logs) }
+                        .padding(horizontal = 10.dp, vertical = 4.dp)
+                ) {
+                    Text(
+                        text = "↓ Exportar",
+                        color = if (logs.isNotEmpty()) Color.White else Color.Gray,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+
+            LazyColumn(
+                modifier = Modifier
+                    .width(320.dp)
+                    .heightIn(max = 420.dp)
+                    .background(Color.Black.copy(alpha = 0.88f), RoundedCornerShape(8.dp))
+                    .padding(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(logs) { log ->
+                    val index = logs.indexOf(log)
+                    val isLatest = index == 0
+                    Column {
+                        Text(
+                            text = if (isLatest) "— Última decisión —" else "— Decisión ${index + 1} anterior —",
+                            color = if (isLatest) Color(0xFF00FF88) else Color.Gray,
+                            fontSize = 9.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            text = log,
+                            color = Color.White,
+                            fontSize = 9.sp,
+                            lineHeight = 13.sp,
+                            fontFamily = FontFamily.Monospace
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun exportAiDebugLog(context: Context, logs: List<String>) {
+    val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+    val sb = StringBuilder()
+    sb.appendLine("=== MusVisto — AI Debug Log ===")
+    sb.appendLine("Exportado: $timestamp")
+    sb.appendLine("Decisiones registradas: ${logs.size}")
+    sb.appendLine("=".repeat(40))
+    sb.appendLine()
+    logs.forEachIndexed { index, log ->
+        val label = if (index == 0) "ÚLTIMA DECISIÓN" else "DECISIÓN ${index + 1} ANTERIOR"
+        sb.appendLine("--- $label ---")
+        sb.appendLine(log)
+        sb.appendLine()
+    }
+
+    // Compartimos el texto directamente (sin FileProvider) para no depender de
+    // declarar el provider en AndroidManifest.
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, sb.toString())
+        putExtra(Intent.EXTRA_SUBJECT, "MusVisto AI Debug Log $timestamp")
+    }
+    context.startActivity(Intent.createChooser(intent, "Compartir log de IA"))
+}

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -13,7 +13,12 @@ import com.doselfurioso.musvisto.model.Rank
 import kotlin.math.max
 
 
-data class AIDecision(val action: GameAction, val cardsToDiscard: Set<Card> = emptySet())
+data class AIDecision(
+    val action: GameAction,
+    val cardsToDiscard: Set<Card> = emptySet(),
+    /** Log detallado de la decisión, consumido por el panel de debug en builds debug. */
+    val debugLog: String = ""
+)
 
 /**
  * Clase AILogic
@@ -124,8 +129,9 @@ class AILogic constructor(
 
         logBuilder.appendLine(actionLog)
         logBuilder.appendLine("================ END AI DECISION [$decisionId] ================\n")
-        Log.d(TAG, logBuilder.toString())
-        return decision
+        val log = logBuilder.toString()
+        Log.d(TAG, log)
+        return decision.copy(debugLog = log)
     }
 
     private fun getPairingRank(rank: Rank): Rank {

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -65,6 +65,7 @@ import com.doselfurioso.musvisto.model.Player
 import com.doselfurioso.musvisto.model.ScoreBreakdown
 import kotlinx.coroutines.delay
 import kotlin.math.abs
+import com.doselfurioso.musvisto.debug.DebugFeatures
 import com.doselfurioso.musvisto.model.Card as CardData
 
 // Custom modifier for the bottom border (no changes here)
@@ -363,9 +364,13 @@ fun GameScreen(
                     navController = navController,
                     onAction = gameViewModel::onAction,
                     humanPlayerId = gameViewModel.humanPlayerId,
-                    dimensions = dimens
+                    dimensions = dimens,
+                    gameViewModel = gameViewModel
                 )
             }
+
+            // Panel flotante de logs de IA — solo se renderiza en builds debug.
+            DebugFeatures.AiDebugPanelOverlay(gameViewModel)
 
             if (gameState.isSelectingBet) {
                 Box(
@@ -878,7 +883,7 @@ private fun PartnerHand(
     revealHand: Boolean,
     dimens: ResponsiveDimens
 ) {
-    val showFaceUp = isDebugMode || revealHand
+    val showFaceUp = (DebugFeatures.IS_ENABLED && isDebugMode) || revealHand
     Row(
         modifier = modifier,
         horizontalArrangement = if (showFaceUp)
@@ -919,7 +924,7 @@ fun SideOpponentHandStacked(modifier: Modifier, cards: List<CardData>, isDebugMo
                         if (rotate) rotationZ = 90f else rotationZ = 270f
                     }
             ) {
-                if (isDebugMode || revealHand) {
+                if ((DebugFeatures.IS_ENABLED && isDebugMode) || revealHand) {
                     GameCard(
                         card = cards[index],
                         isSelected = false,
@@ -1355,7 +1360,8 @@ fun PauseMenuOverlay(
     navController: NavController,
     onAction: (GameAction, String) -> Unit,
     humanPlayerId: String,
-    dimensions: ResponsiveDimens
+    dimensions: ResponsiveDimens,
+    gameViewModel: GameViewModel
 ) {
     Box(
         modifier = Modifier
@@ -1397,6 +1403,9 @@ fun PauseMenuOverlay(
                 ) {
                     Text("Volver al Menú", fontSize = dimensions.fontSizeMedium)
                 }
+
+                // Botón de debug — solo se renderiza en builds debug.
+                DebugFeatures.DebugToggleButton(gameViewModel)
             }
         }
     }

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.doselfurioso.musvisto.R
+import com.doselfurioso.musvisto.debug.DebugFeatures
 import com.doselfurioso.musvisto.logic.AILogic
 import com.doselfurioso.musvisto.logic.GameRepository
 import com.doselfurioso.musvisto.logic.MusGameLogic
@@ -31,6 +32,9 @@ class GameViewModel constructor(
 
     private val _isDebugMode = MutableStateFlow(false)
     val isDebugMode: StateFlow<Boolean> = _isDebugMode.asStateFlow()
+
+    private val _aiDebugLogs = MutableStateFlow<List<String>>(emptyList())
+    val aiDebugLogs: StateFlow<List<String>> = _aiDebugLogs.asStateFlow()
 
     val humanPlayerId = "p1"
 
@@ -290,6 +294,11 @@ class GameViewModel constructor(
                     "MusVistoDebug",
                     "AI (${currentPlayer.name}) decided to: ${aiDecision.action.displayText}"
                 )
+                // En builds release `DebugFeatures.IS_ENABLED` es constante false y R8
+                // elimina el bloque completo, así que el flow queda vacío.
+                if (DebugFeatures.IS_ENABLED && aiDecision.debugLog.isNotEmpty()) {
+                    _aiDebugLogs.value = (listOf(aiDecision.debugLog) + _aiDebugLogs.value).take(20)
+                }
 
                 // Si la acción es descartar, aplicamos la selección de cartas de la IA al estado
                 if (aiDecision.action is GameAction.ConfirmDiscard) {

--- a/app/src/release/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
+++ b/app/src/release/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
@@ -1,0 +1,26 @@
+package com.doselfurioso.musvisto.debug
+
+import androidx.compose.runtime.Composable
+import com.doselfurioso.musvisto.presentation.GameViewModel
+
+/**
+ * Stub no-op para builds de release.
+ *
+ * Esta versión vive en `src/release/` y se compila SOLO en builds release.
+ * La versión real (`src/debug/.../DebugFeatures.kt`) se compila solo en builds debug.
+ * El código de `src/main/` referencia `DebugFeatures` sin saber qué implementación
+ * recibe; el sistema de build variants resuelve la correcta.
+ */
+object DebugFeatures {
+    const val IS_ENABLED = false
+
+    @Composable
+    fun AiDebugPanelOverlay(viewModel: GameViewModel) {
+        // No-op en release.
+    }
+
+    @Composable
+    fun DebugToggleButton(viewModel: GameViewModel) {
+        // No-op en release.
+    }
+}


### PR DESCRIPTION
> ⚠️ **Depende de #10** (`feature/ai-partner-gesture-analysis`) que a su vez depende de #9. Mergear en orden.

## Summary
Reorganiza el panel "AI Debug Log" usando los **build variants** de Android (`src/debug/` vs `src/release/`) para que el APK release quede completamente limpio sin código de debug, sin necesidad de mantener una rama paralela.

### Estructura
- `app/src/release/.../debug/DebugFeatures.kt`: stub no-op, `IS_ENABLED = false`. Solo compila en builds release.
- `app/src/debug/.../debug/DebugFeatures.kt`: implementación real con panel flotante y botón de toggle. Solo compila en builds debug.
- Mismo API (`AiDebugPanelOverlay`, `DebugToggleButton`, `IS_ENABLED`); el sistema de variants resuelve cuál se compila.

### Cambios en `src/main/`
- `AIDecision` recibe campo `debugLog: String = ""`.
- `makeDecision` devuelve `decision.copy(debugLog = log)` con el log que ya construía.
- `GameViewModel` acumula los últimos 20 logs en `_aiDebugLogs`, gated por `DebugFeatures.IS_ENABLED` para que R8 lo elimine en release.
- `GameScreen` llama a los composables de `DebugFeatures` (no-op en release). Reveal de cartas blindado con `(DebugFeatures.IS_ENABLED && isDebugMode)`.

### Build config
- `release { signingConfig = signingConfigs.getByName("debug") }` para poder instalar release localmente sin keystore propio. Cuando se publique se sustituirá por la clave real.

### Bonus
`exportAiDebugLog` usaba `FileProvider` pero no estaba declarado en `AndroidManifest` (habría crasheado al pulsar). Lo simplifiqué a `ACTION_SEND` con `EXTRA_TEXT` directo.

### Consecuencia
Cuando esto se mergee, la rama `feature/ai-debug-panel` queda obsoleta y se puede borrar.

## Test plan
- [x] Tests JUnit pasan.
- [x] `./gradlew compileDebugKotlin` OK.
- [x] `./gradlew compileReleaseKotlin` OK.
- [x] En Android Studio: Build Variants -> cambiar `app` a `release`, recompilar, abrir app y comprobar que NO aparece el botón Debug en pausa ni el overlay AI Log.
- [x] Cambiar a `debug`, recompilar, comprobar que ambos aparecen y funcionan.
