### PR TITLE
fix(ui): rediseño de ActionAnnouncements con máquina de estados local

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/logic/MusGameLogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/MusGameLogic.kt
@@ -268,18 +268,20 @@ class MusGameLogic constructor(private val random: Random){
 
         if (nextState == currentState) return currentState
 
-        // ---- FINALIZACIÓN Y GESTIÓN DE ANUNCIOS (LÓGICA SIMPLIFICADA) ----
+        // ---- FINALIZACIÓN Y GESTIÓN DE ANUNCIOS ----
+        // Mantenemos TODOS los anuncios del lance en el mapa para que coexistan en
+        // pantalla. El ViewModel limpia el mapa tras el tiempo mínimo visible,
+        // justo antes de iniciar el siguiente lance (no aquí, para no borrar de
+        // golpe los anuncios de los demás cuando el último jugador cierra el lance).
         val newActionInfo = LastActionInfo(playerId, action)
         val phaseChanged = currentState.gamePhase != nextState.gamePhase
 
-        // Siempre añadimos la acción al mapa de anuncios. El ViewModel se encargará de limpiarlo.
         val updatedLanceActions = currentState.currentLanceActions + (playerId to newActionInfo)
 
         return nextState.copy(
             lastAction = newActionInfo,
             actionLog = (nextState.actionLog + newActionInfo).takeLast(4),
             currentLanceActions = updatedLanceActions,
-            // Si la fase cambió, marcamos la acción como transitoria.
             transientAction = if (phaseChanged) newActionInfo else null
         )
     }

--- a/app/src/main/java/com/doselfurioso/musvisto/model/LastActionInfo.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/model/LastActionInfo.kt
@@ -6,5 +6,10 @@ import kotlinx.serialization.Serializable
 data class LastActionInfo(
     val playerId: String,
     val action: GameAction,
-    val amount: Int? = null
+    val amount: Int? = null,
+    // Identificador único por instancia. Distingue dos acciones idénticas
+    // (p. ej. "Paso" en Grande y "Paso" en Chica) para que la limpieza de
+    // anuncios entre lances no borre por error una acción nueva con el mismo
+    // contenido que una antigua. Se asigna en cada construcción.
+    val seq: Long = System.nanoTime()
 )

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -1,13 +1,16 @@
 package com.doselfurioso.musvisto.presentation
 
 import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -60,6 +63,7 @@ import com.doselfurioso.musvisto.model.GameEvent
 import com.doselfurioso.musvisto.model.GamePhase
 import com.doselfurioso.musvisto.model.GameState
 import com.doselfurioso.musvisto.model.LanceResult
+import com.doselfurioso.musvisto.model.LastActionInfo
 import com.doselfurioso.musvisto.model.OrdagoInfo
 import com.doselfurioso.musvisto.model.Player
 import com.doselfurioso.musvisto.model.ScoreBreakdown
@@ -67,6 +71,15 @@ import kotlinx.coroutines.delay
 import kotlin.math.abs
 import com.doselfurioso.musvisto.debug.DebugFeatures
 import com.doselfurioso.musvisto.model.Card as CardData
+
+internal const val ANNOUNCEMENT_MIN_VISIBLE_MS = 1200L
+// Piso corto cuando el anuncio es REEMPLAZADO por otra acción (no ocultado):
+// basta un golpe de vista + cross-fade. Evita que la acción anterior del propio
+// jugador se quede colgada cuando actúa muy rápido (p. ej. No Mus -> Paso).
+private const val ANNOUNCEMENT_MIN_BEFORE_REPLACE_MS = 450L
+private const val ANNOUNCEMENT_ENTER_MS = 200
+private const val ANNOUNCEMENT_EXIT_MS = 250
+private const val ANNOUNCEMENT_TEXT_FADE_MS = 180
 
 // Custom modifier for the bottom border (no changes here)
 @SuppressLint("UnnecessaryComposedModifier")
@@ -784,45 +797,70 @@ fun ActionAnnouncement(
     gameState: GameState,
     dimens: ResponsiveDimens
 ) {
-    // transientAction takes priority (end-of-phase action), then persistent — but hide
-    // the persistent action while it's the player's turn to avoid showing a stale
-    // action from a previous betting round within the same lance.
-    // Hide a stale persistent action only when the game is actively waiting for this
-    // player to make a choice (availableActions non-empty). During auto-declaration
-    // sequences (PARES_CHECK / JUEGO_CHECK) availableActions is empty, so announcements
-    // show correctly even for the first player in declaration order.
-    val isWaitingForInput = gameState.currentTurnPlayerId == player.id &&
-            gameState.availableActions.isNotEmpty()
-    val actionToShow = when {
+    // El game state declara QUÉ anuncio quiere mostrar; el composable decide CUÁNDO y CÓMO.
+    // transientAction (la acción que cerró el lance) tiene prioridad sobre la persistente.
+    val targetAction: LastActionInfo? = when {
         gameState.transientAction?.playerId == player.id -> gameState.transientAction
-        isWaitingForInput -> null
         else -> gameState.currentLanceActions[player.id]
     }
 
-    val visible = actionToShow != null
+    var displayedAction by remember { mutableStateOf<LastActionInfo?>(null) }
+    var shownAt by remember { mutableStateOf(0L) }
+
+    LaunchedEffect(targetAction) {
+        val now = System.currentTimeMillis()
+        when {
+            targetAction != null && targetAction != displayedAction -> {
+                if (displayedAction != null) {
+                    val remaining = ANNOUNCEMENT_MIN_BEFORE_REPLACE_MS - (now - shownAt)
+                    if (remaining > 0) delay(remaining)
+                }
+                displayedAction = targetAction
+                shownAt = System.currentTimeMillis()
+            }
+            targetAction == null && displayedAction != null -> {
+                val remaining = ANNOUNCEMENT_MIN_VISIBLE_MS - (now - shownAt)
+                if (remaining > 0) delay(remaining)
+                displayedAction = null
+            }
+        }
+    }
 
     AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn() + slideInVertically(),
-        exit = fadeOut() + slideOutVertically()
+        visible = displayedAction != null,
+        enter = fadeIn(tween(ANNOUNCEMENT_ENTER_MS)) +
+                slideInVertically(tween(ANNOUNCEMENT_ENTER_MS)),
+        exit = fadeOut(tween(ANNOUNCEMENT_EXIT_MS)) +
+                slideOutVertically(tween(ANNOUNCEMENT_EXIT_MS))
     ) {
         Card(
             colors = CardDefaults.cardColors(containerColor = Color.Black.copy(alpha = 0.7f)),
             modifier = Modifier.padding(4.dp * dimens.scaleFactor)
         ) {
-            if (actionToShow?.action is GameAction.ConfirmDiscard) Text(
-                text = ("Dame ${gameState.discardCounts[player.id]}"),
-                color = Color.White,
-                fontWeight = FontWeight.Bold,
-                fontSize = dimens.fontSizeLarge,
-                modifier = Modifier.padding(horizontal = 12.dp * dimens.scaleFactor, vertical = 5.dp * dimens.scaleFactor)
-            ) else Text(
-                text = actionToShow?.action?.displayText ?: "",
-                color = Color.White,
-                fontWeight = FontWeight.Bold,
-                fontSize = dimens.fontSizeLarge,
-                modifier = Modifier.padding(horizontal = 12.dp * dimens.scaleFactor, vertical = 5.dp * dimens.scaleFactor)
-            )
+            AnimatedContent(
+                targetState = displayedAction,
+                transitionSpec = {
+                    fadeIn(tween(ANNOUNCEMENT_TEXT_FADE_MS)) togetherWith
+                            fadeOut(tween(ANNOUNCEMENT_TEXT_FADE_MS))
+                },
+                label = "ActionAnnouncementText"
+            ) { action ->
+                val text = if (action?.action is GameAction.ConfirmDiscard) {
+                    "Dame ${gameState.discardCounts[player.id]}"
+                } else {
+                    action?.action?.displayText ?: ""
+                }
+                Text(
+                    text = text,
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = dimens.fontSizeLarge,
+                    modifier = Modifier.padding(
+                        horizontal = 12.dp * dimens.scaleFactor,
+                        vertical = 5.dp * dimens.scaleFactor
+                    )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
@@ -350,30 +350,36 @@ class GameViewModel constructor(
 
         // Lanzamos una corrutina para gestionar la secuencia de forma ordenada
         viewModelScope.launch {
-            // SI LA FASE HA CAMBIADO, significa que un lance acaba de terminar.
-            // Ahora, nos detenemos y esperamos a que su último anuncio desaparezca.
+            // Si la fase ha cambiado, damos al composable ActionAnnouncement el
+            // tiempo mínimo visible para mostrar la acción que cerró el lance
+            // (y mantener visibles los anuncios de los demás jugadores). Pasado
+            // ese tiempo, limpiamos el estado de anuncios ANTES de continuar para
+            // que el siguiente lance no arrastre nada. Cada composable aplica su
+            // propia animación de salida respetando su mínimo individual.
             if (phaseChanged) {
-                // La información del último anuncio está en `newState.transientAction`
-                // Le damos 1.5 segundos para que se muestre y su animación de salida termine.
-                delay(500)
+                // Capturamos los anuncios del lance que acaba de cerrar ANTES de
+                // esperar. Tras el tiempo mínimo solo eliminamos esas instancias
+                // concretas: si el jugador ya actuó en el lance nuevo, su nueva
+                // acción tiene otro `seq` (LastActionInfo.seq es único por
+                // instancia) y NO se borra, aunque sea la misma acción repetida.
+                val staleActions = _gameState.value.currentLanceActions
+                val staleTransient = _gameState.value.transientAction
+                delay(ANNOUNCEMENT_MIN_VISIBLE_MS)
                 awaitNotPaused()
-                _gameState.value = _gameState.value.copy(currentLanceActions = emptyMap())
-                delay(500)
-                awaitNotPaused()
-
-
-                // Pasado el tiempo, nos aseguramos de que el estado esté limpio
-                // antes de continuar.
-                if (_gameState.value.transientAction == newState.transientAction) {
-                    _gameState.value = _gameState.value.copy(
-                        transientAction = null,
-                        currentLanceActions = emptyMap()
-                    )
-                }
+                val current = _gameState.value
+                _gameState.value = current.copy(
+                    currentLanceActions = current.currentLanceActions
+                        .filterNot { (id, info) -> staleActions[id] == info },
+                    transientAction = if (current.transientAction == staleTransient) {
+                        null
+                    } else {
+                        current.transientAction
+                    }
+                )
             }
 
-            // AHORA que la pantalla está limpia, continuamos con el lance actual.
-            val currentState = _gameState.value // Volvemos a leer el estado por si ha cambiado
+            // Continuamos con el lance actual.
+            val currentState = _gameState.value
             if (currentState.gamePhase == GamePhase.PARES_CHECK || currentState.gamePhase == GamePhase.JUEGO_CHECK) {
                 handleDeclarationSequence(currentState)
             } else {
@@ -409,8 +415,9 @@ class GameViewModel constructor(
                 setGameState(tempState)
             }
 
-            // Una vez que todos han hablado, hacemos una última pausa y avanzamos a la siguiente fase
-            delay(1000)
+            // Una vez que todos han hablado, hacemos una última pausa (alineada
+            // con el mínimo visible del composable) y avanzamos a la siguiente fase.
+            delay(ANNOUNCEMENT_MIN_VISIBLE_MS)
             awaitNotPaused()
             // La función endLanceAndAdvance es la que contiene la lógica para saltar lances si es necesario
             val finalState = gameLogic.resolveDeclaration(tempState)


### PR DESCRIPTION
## Contexto

Los usuarios reportaban que las acciones de cada jugador (paso, envido, mus, no mus, etc.) no quedaban claras: los anuncios aparecían/desaparecían de forma extraña. La causa raíz era que el timing visual estaba acoplado a los delays de la corrutina del `GameViewModel`.

## Cambios

- **`ActionAnnouncement`**: máquina de estados local con `LaunchedEffect` + estado `remember`. Garantiza un mínimo visible (1200 ms), anima entrada/salida con `tween` explícitos y hace cross-fade del texto con `AnimatedContent`.
- **Piso corto de reemplazo (450 ms)**: cuando un anuncio es sustituido por otra acción (no ocultado), no se retiene el mínimo completo — evita que las acciones rápidas del jugador (p. ej. No Mus → Paso) se queden colgadas.
- **`GameViewModel`**: eliminada la coreografía de `delay(500)+delay(500)` y la limpieza ciega de `currentLanceActions`. Ahora, tras el mínimo visible, solo se eliminan las instancias del lance anterior.
- **`LastActionInfo.seq`**: id único por instancia para distinguir acciones idénticas de lances distintos y evitar parpadeos en la limpieza.
- Eliminada la condición `isWaitingForInput`: el jugador humano ve su propio anuncio igual que la IA.

## Verificación

- `gradlew assembleDebug` y `testDebugUnitTest` en verde.
- Probado manualmente: envites consecutivos, PARES_CHECK/JUEGO_CHECK, cambios de lance, acciones rápidas del humano (No Mus → Paso), persistencia entre lances.