### PR TITLE
fix(ui): el anuncio de acción ya no desplaza cartas ni elementos

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -998,8 +998,10 @@ fun VerticalPlayerArea(
         Box(
             modifier = Modifier.layout { measurable, constraints ->
                 val placeable = measurable.measure(constraints.copy(minWidth = 0, minHeight = 0))
-                layout(placeable.width, 0) {
-                    placeable.placeRelative(0, -placeable.height)
+                // Tamaño 0 en ambos ejes: overlay puro, no desplaza a los hermanos
+                // por mucho que crezca el texto. Se centra sobre el avatar.
+                layout(0, 0) {
+                    placeable.placeRelative(-placeable.width / 2, -placeable.height)
                 }
             }
         ) {
@@ -1041,8 +1043,9 @@ fun HorizontalPlayerArea(
                 Box(
                     modifier = Modifier.layout { measurable, constraints ->
                         val placeable = measurable.measure(constraints.copy(minWidth = 0, minHeight = 0))
-                        layout(placeable.width, 0) {
-                            placeable.placeRelative(0, -placeable.height)
+                        // Tamaño 0: overlay centrado sobre el avatar, no reordena la fila.
+                        layout(0, 0) {
+                            placeable.placeRelative(-placeable.width / 2, -placeable.height)
                         }
                     }
                 ) {
@@ -1054,8 +1057,9 @@ fun HorizontalPlayerArea(
                 Box(
                     modifier = Modifier.layout { measurable, constraints ->
                         val placeable = measurable.measure(constraints.copy(minWidth = 0, minHeight = 0))
-                        layout(placeable.width, 0) {
-                            placeable.placeRelative(0, 0)
+                        // Tamaño 0: overlay centrado bajo el avatar, no reordena la fila.
+                        layout(0, 0) {
+                            placeable.placeRelative(-placeable.width / 2, 0)
                         }
                     }
                 ) {


### PR DESCRIPTION
## Contexto

Cuando el texto del anuncio era largo (p. ej. "No tengo"), desplazaba el resto de elementos: en los jugadores superior/inferior empujaba las cartas. Se veía raro que la interfaz se moviera al aparecer/cambiar un anuncio.

## Causa

Los tres bloques `Modifier.layout` que envuelven `ActionAnnouncement` reportaban `layout(placeable.width, 0)`: desacoplaban la altura (height 0) pero **no la anchura**, así que la anchura variable del anuncio ensanchaba la `Column` y reordenaba a los hermanos.

## Cambio

Reportar `layout(0, 0)` (tamaño cero en ambos ejes) y centrar el anuncio sobre/bajo el avatar con `placeRelative(-placeable.width / 2, ...)`. El anuncio queda como overlay puro: ni alto ni ancho afectan al layout. Bonus: ahora queda centrado respecto al avatar (antes anclado a la izquierda).

## Verificación

- `gradlew assembleDebug` en verde.
- Verificado manualmente en emulador: las cartas ya no se mueven, el texto queda centrado sobre el avatar y textos largos no reordenan la interfaz.