### PR TITLE
fix(ui): separar el avatar del jugador inferior del borde izquierdo

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -316,7 +316,8 @@ fun GameScreen(
                         dimens = dimens,
                         modifier = Modifier.align(Alignment.BottomCenter),
                         gameState = gameState,
-                        announcementAbove = true
+                        announcementAbove = true,
+                        avatarLeadingPadding = dimens.defaultPadding * 2
                     )
 
                     // Botones de acción — superpuestos en la parte superior, encima de las cartas


### PR DESCRIPTION
## Contexto

El avatar del jugador inferior quedaba pegado al borde izquierdo de la pantalla y se veía raro.

## Cambio

`HorizontalPlayerArea` ya soportaba `avatarLeadingPadding` pero el jugador inferior usaba el default `0.dp`. Se pasa `dimens.defaultPadding * 2` (margen responsive intermedio) para separarlo del borde y alinearlo visualmente con los botones de seña y pausa.

## Verificación

- `gradlew assembleDebug` en verde.
- Verificado manualmente en emulador.