### PR TITLE
feat(ai): tanda de jugabilidad de IA + legibilidad del log de debug

### DIFF
--- a/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
+++ b/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -55,7 +56,11 @@ object DebugFeatures {
         if (!isDebugMode) return
 
         val logs by viewModel.aiDebugLogs.collectAsState()
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .navigationBarsPadding()
+        ) {
             AiDebugPanel(
                 logs = logs,
                 modifier = Modifier

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -105,7 +105,7 @@ class AILogic constructor(
         } else {
             when (gameState.gamePhase) {
                 GamePhase.MUS -> {
-                    val musResult = decideMus(finalStrength, aiPlayer, riskFactor)
+                    val musResult = decideMus(finalStrength, aiPlayer, riskFactor, gameState)
                     decision = AIDecision(musResult.first)
                     actionLog = ">>> FINAL ACTION: ${musResult.first.displayText} (${musResult.second})"
                 }
@@ -222,21 +222,36 @@ class AILogic constructor(
     private fun decideMus(
         strength: HandStrength,
         aiPlayer: Player,
-        riskFactor: Int
+        riskFactor: Int,
+        gameState: GameState
     ): Pair<GameAction, String> {
         // --- LÓGICA DE CORTAR MUS MEJORADA ---
         // Ya no se basa en el tipo de jugada, sino en la fuerza calculada.
-        val paresCutThreshold = 75 - riskFactor // Umbral para cortar por pares
-        val juegoCutThreshold = 75 - riskFactor
-        val grandeCutThreshold = 85 - riskFactor
-        val chicaCutThreshold = 85 - riskFactor
 
-        if (strength.pares >= paresCutThreshold) return Pair(GameAction.NoMus, "Reason: Pares strength ${strength.pares} >= threshold $paresCutThreshold")
-        if (strength.juego >= juegoCutThreshold) return Pair(GameAction.NoMus, "Reason: Juego strength ${strength.juego} >= threshold $juegoCutThreshold")
-        if (strength.grande >= grandeCutThreshold) return Pair(GameAction.NoMus, "Reason: Grande strength ${strength.grande} >= threshold $grandeCutThreshold")
-        if (strength.chica >= chicaCutThreshold) return Pair(GameAction.NoMus, "Reason: Chica strength ${strength.chica} >= threshold $chicaCutThreshold")
+        // "No quitar mano al compañero": si el compañero es mano, cortar el Mus
+        // con una mano solo normalita le roba la opción de mejorar y su ventaja
+        // posicional/de desempate. Subimos el listón de corte: solo se corta con
+        // mano claramente buena (que supera incluso el umbral elevado).
+        val partner = gameState.players.firstOrNull { it.team == aiPlayer.team && it.id != aiPlayer.id }
+        val partnerIsMano = partner != null && gameState.manoPlayerId == partner.id
+        val manoBias = if (partnerIsMano) 10 else 0
 
-        return Pair(GameAction.Mus, "Reason: No strength exceeds thresholds to cut mus (treshold - riskfactor) Grande/Chica = 85. Pares/Juego = 75")
+        val paresCutThreshold = 75 - riskFactor + manoBias // Umbral para cortar por pares
+        val juegoCutThreshold = 75 - riskFactor + manoBias
+        val grandeCutThreshold = 85 - riskFactor + manoBias
+        val chicaCutThreshold = 85 - riskFactor + manoBias
+
+        if (strength.pares >= paresCutThreshold) return Pair(GameAction.NoMus, "Reason: Pares strength ${strength.pares} >= threshold $paresCutThreshold (manoBias $manoBias)")
+        if (strength.juego >= juegoCutThreshold) return Pair(GameAction.NoMus, "Reason: Juego strength ${strength.juego} >= threshold $juegoCutThreshold (manoBias $manoBias)")
+        if (strength.grande >= grandeCutThreshold) return Pair(GameAction.NoMus, "Reason: Grande strength ${strength.grande} >= threshold $grandeCutThreshold (manoBias $manoBias)")
+        if (strength.chica >= chicaCutThreshold) return Pair(GameAction.NoMus, "Reason: Chica strength ${strength.chica} >= threshold $chicaCutThreshold (manoBias $manoBias)")
+
+        val musReason = if (partnerIsMano) {
+            "Reason: No strength exceeds thresholds; compañero es mano, sesgo a Mus (manoBias +$manoBias)"
+        } else {
+            "Reason: No strength exceeds thresholds to cut mus"
+        }
+        return Pair(GameAction.Mus, musReason)
     }
 
 

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -203,7 +203,7 @@ class AILogic constructor(
 
             // REGLA 2: Si la ventaja es muy grande (>85), sube la apuesta — cantidad aleatoria 2-4
             // para que la IA sea menos predecible.
-            advantage > 85 -> GameAction.Envido(rng.nextInt(2, 5))
+            advantage > 85 -> GameAction.Envido(betAmount(adjustedStrength))
 
             // REGLA 3: El umbral para aceptar un envite ("Quiero") es más exigente.
             advantage > 70 -> GameAction.Quiero
@@ -240,6 +240,16 @@ class AILogic constructor(
     }
 
 
+    // Importe de envite sesgado por la fuerza de la jugada: con mano floja
+    // (justo sobre el umbral) envida poco; con mano muy fuerte sube más.
+    // Mantiene aleatoriedad dentro de cada tramo para no ser predecible.
+    private fun betAmount(strength: Int): Int = when {
+        strength >= 90 -> rng.nextInt(4, 6)  // 4-5: manos muy fuertes (3+ reyes, 31)
+        strength >= 80 -> rng.nextInt(3, 6)  // 3-5
+        strength >= 70 -> rng.nextInt(2, 5)  // 2-4
+        else -> rng.nextInt(2, 4)            // 2-3: manos justas
+    }
+
     private fun decideInitialBet(
         strength: Int,
         aiPlayer: Player,
@@ -269,11 +279,12 @@ class AILogic constructor(
         val bluffChance = 5 + (strength / 10)
 
         if (strength > betThreshold) {
-            val amount = rng.nextInt(2, 5)
+            val amount = betAmount(strength)
             return Pair(GameAction.Envido(amount), "Reason: Strength $strength > bet threshold $betThreshold")
         }
         if (strength > bluffThreshold && rng.nextInt(100) < bluffChance) {
-            return Pair(GameAction.Envido(rng.nextInt(2, 5)), "Reason: Bluff! Strength $strength > bluff threshold $bluffThreshold (Chance: $bluffChance%)")
+            // El farol se mantiene barato a propósito: mano débil, limitar pérdida.
+            return Pair(GameAction.Envido(rng.nextInt(2, 4)), "Reason: Bluff! Strength $strength > bluff threshold $bluffThreshold (Chance: $bluffChance%)")
         }
 
         return Pair(GameAction.Paso, "Reason: Strength $strength is below thresholds (Bet > $betThreshold, Bluff > $bluffThreshold)")
@@ -525,15 +536,17 @@ class AILogic constructor(
         explanation.appendLine("   - Juego (Valor: $juegoValue, Posición: ${playerPositionInTurn + 1}):")
 
         if (juegoValue >= 31) {
+            // El 31 es premium (además suma +1 tanto por "juego de 31"). El resto
+            // baja con un salto claro: un 32 es decente pero NO está cerca del 31.
             val baseJuegoStrength = when (juegoValue) {
-                31 -> 95  // Mejor juego
-                32 -> 85  // Segundo mejor
-                40 -> 75  // Tercero
-                37 -> 65
-                36 -> 60
-                35 -> 55
-                34 -> 52
-                else -> 50  // 33, el peor juego
+                31 -> 95  // Mejor juego, con diferencia
+                32 -> 70  // Segundo, pero lejos del 31
+                40 -> 60
+                37 -> 52
+                36 -> 48
+                35 -> 44
+                34 -> 41
+                else -> 38  // 33, el peor juego
             }
             juegoStrength = baseJuegoStrength
             explanation.appendLine("     - JUEGO: Base por valor $juegoValue -> $juegoStrength pts")
@@ -541,6 +554,15 @@ class AILogic constructor(
             if (juegoValue == 31 && !isMano) {
                 juegoStrength -= 15
                 explanation.appendLine("     - Penalización por tener 31 sin ser mano -> -15 pts")
+            }
+
+            // Los empates de Juego los gana quien está más cerca de mano. Con un
+            // juego no-31 (empatable a menudo), cuanto más tarde se actúa peor:
+            // un 32 en postre pierde el desempate. Penaliza por posición.
+            if (juegoValue in 32..40 && playerPositionInTurn > 0) {
+                val posPenalty = playerPositionInTurn * 6
+                juegoStrength -= posPenalty
+                explanation.appendLine("     - Penalización por posición ${playerPositionInTurn + 1} con juego no-31 -> -$posPenalty pts")
             }
         } else {
             // --- NUEVA LÓGICA PARA PUNTO ---

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -56,9 +56,14 @@ class AILogic constructor(
         val decisionId = UUID.randomUUID().toString().substring(0, 5)
         val logBuilder = StringBuilder()
 
+        val rivalTeam = if (aiPlayer.team == "teamA") "teamB" else "teamA"
+        val myScore = gameState.score[aiPlayer.team] ?: 0
+        val rivalScore = gameState.score[rivalTeam] ?: 0
+        val handStr = handToShortString(aiPlayer.hand)
+
         logBuilder.appendLine("================ AI DECISION [$decisionId] ================")
-        logBuilder.appendLine("Player: ${aiPlayer.name} | Hand: ${aiPlayer.hand.joinToString { cardToShortString(it) }}")
-        logBuilder.appendLine("Phase: ${gameState.gamePhase} | Score: Nosotros ${gameState.score["teamA"]} - Ellos ${gameState.score["teamB"]}")
+        logBuilder.appendLine("Player: ${aiPlayer.name} | Mano: $handStr")
+        logBuilder.appendLine("Phase: ${gameState.gamePhase} | Marcador: Mi equipo $myScore - Rival $rivalScore")
         logBuilder.appendLine("-------------------------------------------------")
 
         val evaluation = evaluateHand(aiPlayer.hand, aiPlayer, gameState)
@@ -83,7 +88,21 @@ class AILogic constructor(
             pares = (gestureAdjustedStrength.pares + riskFactor).coerceIn(0, 100),
             juego = (gestureAdjustedStrength.juego + riskFactor).coerceIn(0, 100)
         )
-        logBuilder.appendLine("4. Final Strength -> G:${finalStrength.grande}, C:${finalStrength.chica}, P:${finalStrength.pares}, J:${finalStrength.juego}")
+        // Resalta [..*] la cifra del lance que se está decidiendo.
+        val activeLance = when (gameState.gamePhase) {
+            GamePhase.GRANDE -> "G"; GamePhase.CHICA -> "C"
+            GamePhase.PARES -> "P"; GamePhase.JUEGO -> "J"
+            else -> ""
+        }
+        fun lancePart(letter: String, value: Int) =
+            if (letter == activeLance) "[$letter:$value*]" else "$letter:$value"
+        val finalLine = listOf(
+            lancePart("G", finalStrength.grande),
+            lancePart("C", finalStrength.chica),
+            lancePart("P", finalStrength.pares),
+            lancePart("J", finalStrength.juego)
+        ).joinToString(" ")
+        logBuilder.appendLine("4. Final Strength -> $finalLine")
         logBuilder.appendLine("-------------------------------------------------")
 
         val decision: AIDecision
@@ -160,7 +179,23 @@ class AILogic constructor(
 
         logBuilder.appendLine(actionLog)
         logBuilder.appendLine("================ END AI DECISION [$decisionId] ================\n")
-        val log = logBuilder.toString()
+
+        // Línea TL;DR al principio: lo esencial de un vistazo. El detalle
+        // verboso queda debajo para cuando haga falta profundizar.
+        val activeVal = when (gameState.gamePhase) {
+            GamePhase.GRANDE -> finalStrength.grande
+            GamePhase.CHICA -> finalStrength.chica
+            GamePhase.PARES -> finalStrength.pares
+            GamePhase.JUEGO -> finalStrength.juego
+            else -> null
+        }
+        val tldr = buildString {
+            append("» ${gameState.gamePhase} | $handStr")
+            if (activeLance.isNotEmpty() && activeVal != null) append(" | $activeLance:$activeVal")
+            if (playSupport) append(" | APOYO")
+            append(" -> ${decision.action.displayText}")
+        }
+        val log = "$tldr\n${logBuilder}"
         Log.d(TAG, log)
         return decision.copy(debugLog = log)
     }
@@ -188,19 +223,21 @@ class AILogic constructor(
         else      -> card.rank.value
     }
 
-    private fun cardToShortString(card: Card): String {
-        val r = when (card.rank) {
-            Rank.AS -> "A"
-            Rank.DOS -> "2"
-            Rank.TRES -> "3"
-            Rank.SOTA -> "S"
-            Rank.CABALLO -> "C"
-            Rank.REY -> "R"
-            else -> card.rank.value.toString()
-        }
-        val s = card.suit.name.first()
-        return "$r$s"
+    // Solo el rango: en Mus el palo no influye en puntuación, pares ni juego.
+    private fun cardToShortString(card: Card): String = when (card.rank) {
+        Rank.AS -> "A"
+        Rank.DOS -> "2"
+        Rank.TRES -> "3"
+        Rank.SOTA -> "S"
+        Rank.CABALLO -> "C"
+        Rank.REY -> "R"
+        else -> card.rank.value.toString()
     }
+
+    // Mano ordenada de mayor a menor para lectura rápida en el log.
+    private fun handToShortString(hand: List<Card>): String =
+        hand.sortedByDescending { getCardGrandeValue(it) }
+            .joinToString(" ") { cardToShortString(it) }
 
     // ---------------- Responder a apuestas activas ----------------
     private fun decideResponse(
@@ -611,8 +648,7 @@ class AILogic constructor(
         // --- CÁLCULO DE JUEGO ---
         val juegoValue = gameLogic.getHandJuegoValue(hand)
         var juegoStrength = 0
-        explanation.appendLine("   - Juego (Valor: $juegoValue, Es Mano: $isMano):")
-        explanation.appendLine("   - Juego (Valor: $juegoValue, Posición: ${playerPositionInTurn + 1}):")
+        explanation.appendLine("   - Juego (Valor: $juegoValue, Posición: ${playerPositionInTurn + 1}, Es Mano: $isMano):")
 
         if (juegoValue >= 31) {
             // El 31 es premium (además suma +1 tanto por "juego de 31"). El resto

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -273,8 +273,17 @@ class AILogic constructor(
             // para que la IA sea menos predecible.
             advantage > 85 -> GameAction.Envido(betAmount(adjustedStrength))
 
-            // REGLA 3: El umbral para aceptar un envite ("Quiero") es más exigente.
-            advantage > 70 -> GameAction.Quiero
+            // REGLA 3: ventaja buena -> casi siempre Quiero, pero NO 100%
+            // explotable: cuanto mayor el envite (y la ventaja no aplastante,
+            // que ya cae en REGLA 2), alguna probabilidad de no querer. Evita
+            // que un rival farmee envidando grande contra, p. ej., un 31 en
+            // postre (que pierde el desempate). Los envites pequeños se quieren.
+            advantage > 70 -> {
+                val foldChance = (((currentBetAmount - 2).coerceAtLeast(0)) * 4)
+                    .coerceAtMost(25)
+                if (rng.nextInt(100) < foldChance) GameAction.NoQuiero
+                else GameAction.Quiero
+            }
 
             // REGLA 4: La probabilidad de "pagar por ver" con una mano mediocre es menor.
             advantage > 60 && rng.nextInt(100) < 20 -> GameAction.Quiero // 20% de probabilidad
@@ -666,9 +675,13 @@ class AILogic constructor(
             juegoStrength = baseJuegoStrength
             explanation.appendLine("     - JUEGO: Base por valor $juegoValue -> $juegoStrength pts")
 
-            if (juegoValue == 31 && !isMano) {
-                juegoStrength -= 15
-                explanation.appendLine("     - Penalización por tener 31 sin ser mano -> -15 pts")
+            // El 31 gana a TODO salvo a otro 31 más cercano a mano. Penaliza
+            // por posición (suave: el único riesgo es "otro 31"), no plano:
+            // un 31 en postre puede perder ante 31 de pos 1, 2 ó 3.
+            if (juegoValue == 31 && playerPositionInTurn > 0) {
+                val posPenalty = playerPositionInTurn * 5
+                juegoStrength -= posPenalty
+                explanation.appendLine("     - 31 sin ser mano, posición ${playerPositionInTurn + 1} -> -$posPenalty pts")
             }
 
             // Los empates de Juego los gana quien está más cerca de mano. Con un

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -12,6 +12,10 @@ import com.doselfurioso.musvisto.model.Player
 import com.doselfurioso.musvisto.model.Rank
 import kotlin.math.max
 
+// Por debajo de esta fuerza propia (pre-fusión con señas) en un lance, la mano
+// no es independientemente fuerte: si el compañero señalizó y tiene mejor
+// posición, conviene jugar de apoyo en vez de pisarle el envite.
+private const val SUPPORT_OWN_FLOOR = 70
 
 data class AIDecision(
     val action: GameAction,
@@ -85,6 +89,18 @@ class AILogic constructor(
         val decision: AIDecision
         val actionLog: String
 
+        // Capitanía de lance (#1/#4): ¿debo jugar de apoyo y cederle la
+        // iniciativa al compañero (mejor posición + seña fuerte conocida)?
+        val ownBaseLance = when (gameState.gamePhase) {
+            GamePhase.GRANDE -> baseStrength.grande
+            GamePhase.CHICA -> baseStrength.chica
+            GamePhase.PARES -> baseStrength.pares
+            GamePhase.JUEGO -> baseStrength.juego
+            else -> 0
+        }
+        val playSupport = shouldPlaySupport(gameState, aiPlayer, gameState.gamePhase, ownBaseLance)
+        if (playSupport) logBuilder.appendLine("4b. Rol de APOYO: compañero capitán de lance (mejor posición + seña fuerte), mano propia floja ($ownBaseLance).")
+
         if (gameState.currentBet != null) {
             val strengthForLance = when (gameState.gamePhase) {
                 GamePhase.GRANDE -> finalStrength.grande
@@ -93,14 +109,21 @@ class AILogic constructor(
                 GamePhase.JUEGO -> finalStrength.juego
                 else -> 0
             }
-            val responseAction = decideResponse(strengthForLance, gameState, aiPlayer)
+            val rawResponse = decideResponse(strengthForLance, gameState, aiPlayer)
+            // En apoyo no escalo: una subida (Envido/Órdago) se rebaja a Quiero
+            // para mantener el bote del equipo sin pisar al capitán.
+            val responseAction = if (playSupport &&
+                (rawResponse is GameAction.Envido || rawResponse is GameAction.Órdago)
+            ) GameAction.Quiero else rawResponse
             decision = AIDecision(responseAction)
-            // Log para la respuesta
             val threshold = 70 // Umbral para "Quiero"
-            actionLog = if (responseAction is GameAction.Quiero) {
-                ">>> FINAL ACTION: Quiero (Reason: Strength $strengthForLance >= threshold $threshold)"
-            } else {
-                ">>> FINAL ACTION: ${responseAction.displayText} (Reason: Strength $strengthForLance < threshold $threshold)"
+            actionLog = when {
+                playSupport && responseAction !== rawResponse ->
+                    ">>> FINAL ACTION: Quiero (Apoyo: rebajado desde ${rawResponse.displayText} para no pisar al capitán)"
+                responseAction is GameAction.Quiero ->
+                    ">>> FINAL ACTION: Quiero (Reason: Strength $strengthForLance >= threshold $threshold)"
+                else ->
+                    ">>> FINAL ACTION: ${responseAction.displayText} (Reason: Strength $strengthForLance < threshold $threshold)"
             }
         } else {
             when (gameState.gamePhase) {
@@ -121,8 +144,16 @@ class AILogic constructor(
                         else -> finalStrength.juego
                     }
                     val betResult = decideInitialBet(strengthForLance, aiPlayer, gameState)
-                    decision = AIDecision(betResult.first)
-                    actionLog = ">>> FINAL ACTION: ${betResult.first.displayText} (${betResult.second})"
+                    // En apoyo no abro: dejo hablar a rivales y al capitán.
+                    val betAction = if (playSupport &&
+                        (betResult.first is GameAction.Envido || betResult.first is GameAction.Órdago)
+                    ) GameAction.Paso else betResult.first
+                    decision = AIDecision(betAction)
+                    actionLog = if (playSupport && betAction !== betResult.first) {
+                        ">>> FINAL ACTION: Paso (Apoyo: no abro desde mala posición, cedo al capitán; era ${betResult.first.displayText})"
+                    } else {
+                        ">>> FINAL ACTION: ${betResult.first.displayText} (${betResult.second})"
+                    }
                 }
             }
         }
@@ -219,6 +250,39 @@ class AILogic constructor(
     }
 
     // ---------------- Mus / NoMus ----------------
+    // Capitanía de lance por posición (#1/#4): si el compañero ya señalizó
+    // fuerza para este lance y actúa DESPUÉS que yo (mejor posición), y mi mano
+    // propia es floja, debo jugar de apoyo: ni abrir ni subir, para no pisarle
+    // ni delatar la jugada conocida hablando antes el de mano débil.
+    private fun shouldPlaySupport(
+        gameState: GameState,
+        aiPlayer: Player,
+        lance: GamePhase,
+        ownBaseLanceStrength: Int
+    ): Boolean {
+        if (ownBaseLanceStrength >= SUPPORT_OWN_FLOOR) return false
+        val partner = gameState.players.firstOrNull {
+            it.team == aiPlayer.team && it.id != aiPlayer.id
+        } ?: return false
+        val order = gameLogic.getTurnOrderedPlayers(gameState.players, gameState.manoPlayerId)
+        val myPos = order.indexOfFirst { it.id == aiPlayer.id }
+        val partnerPos = order.indexOfFirst { it.id == partner.id }
+        if (myPos < 0 || partnerPos < 0) return false
+        // Capitán = el que actúa más tarde (mejor posición). Si lo soy, no apoyo.
+        if (myPos > partnerPos) return false
+        val partnerGesture = gameState.knownGestures[partner.id] ?: return false
+        val resId = partnerGesture.gestureResId
+        return when (lance) {
+            GamePhase.GRANDE -> partnerGrandeBoost(resId) >= 65
+            GamePhase.CHICA -> partnerChicaBoost(resId) >= 65
+            GamePhase.PARES -> getGestureMeaning(resId).let {
+                it is GestureMeaning.Pares && it.play !is ParesPlay.NoPares
+            }
+            GamePhase.JUEGO -> getGestureMeaning(resId) is GestureMeaning.Juego
+            else -> false
+        }
+    }
+
     private fun decideMus(
         strength: HandStrength,
         aiPlayer: Player,

--- a/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
+++ b/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
@@ -41,6 +41,51 @@ class AILogicTest {
         assertFalse("No debe tirar el As (preserva Chica)", decision.cardsToDiscard.contains(Card(Suit.BASTOS, Rank.AS)))
     }
 
+    // --- TESTS DECISIÓN DE MUS (#5: no quitar mano al compañero) ---
+
+    @Test
+    fun `decideMus - clearly strong hand still cuts Mus even if partner is mano`() {
+        // 4 Reyes (Grande=100). Aunque el compañero sea mano (umbral +10 -> 95),
+        // 100 >= 95: una mano claramente buena se corta igual (beneficia al equipo).
+        val hand = listOf(Card(Suit.OROS, Rank.REY), Card(Suit.COPAS, Rank.REY), Card(Suit.ESPADAS, Rank.REY), Card(Suit.BASTOS, Rank.REY))
+        val ai = testPlayer.copy(hand = hand)            // teamB
+        val partner = Player(id = "ai2", name = "Compa", team = "teamB", avatarResId = 0, isAi = true)
+        val gameState = GameState(
+            players = listOf(ai, partner, opponentPlayer),
+            gamePhase = GamePhase.MUS,
+            manoPlayerId = partner.id                     // el compañero es mano
+        )
+        val decision = aiLogic.makeDecision(gameState, ai)
+        assertTrue(decision.action is GameAction.NoMus)
+    }
+
+    @Test
+    fun `decideMus - partner-mano bias never makes the AI cut more (no inversion)`() {
+        // Invariante: subir el umbral solo puede convertir NoMus -> Mus, nunca al
+        // revés. Para CUALQUIER mano, si con rival-mano pide Mus, con compañero-mano
+        // también debe pedir Mus.
+        val hand = listOf(Card(Suit.OROS, Rank.REY), Card(Suit.COPAS, Rank.CABALLO), Card(Suit.ESPADAS, Rank.SOTA), Card(Suit.BASTOS, Rank.CINCO))
+        val ai = testPlayer.copy(hand = hand)            // teamB
+        val partner = Player(id = "ai2", name = "Compa", team = "teamB", avatarResId = 0, isAi = true)
+
+        val opponentMano = GameState(
+            players = listOf(ai, partner, opponentPlayer),
+            gamePhase = GamePhase.MUS,
+            manoPlayerId = opponentPlayer.id
+        )
+        val partnerMano = opponentMano.copy(manoPlayerId = partner.id)
+
+        val withOpponentMano = aiLogic.makeDecision(opponentMano, ai).action
+        val withPartnerMano = aiLogic.makeDecision(partnerMano, ai).action
+
+        if (withOpponentMano is GameAction.Mus) {
+            assertTrue(
+                "El sesgo de compañero-mano no debe hacer que la IA corte más",
+                withPartnerMano is GameAction.Mus
+            )
+        }
+    }
+
     // --- NUEVOS TESTS DE DECISIONES DE LA IA ---
 
     @Test

--- a/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
+++ b/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
@@ -63,16 +63,14 @@ class AILogicTest {
     }
 
     @Test
-    fun `makeDecision - IA should make a standard bet even with a great hand due to conservative logic`() {
-        // --- TEST CORREGIDO ---
-        // AHORA: Comprobamos que, con tres Reyes, la IA hace el envite estándar de 2,
-        // porque su personalidad ya no es tan agresiva.
+    fun `makeDecision - IA should bet bigger with a great hand (strength-scaled amount)`() {
+        // Con tres Reyes (mano muy fuerte a Grande) el importe se escala por
+        // fuerza: betAmount con strength alta -> tramo 3..5 (ya no 2 fijo).
         val hand = listOf(Card(Suit.OROS, Rank.REY), Card(Suit.COPAS, Rank.REY), Card(Suit.ESPADAS, Rank.REY), Card(Suit.BASTOS, Rank.CABALLO))
         val gameState = GameState(players = listOf(testPlayer.copy(hand = hand)), gamePhase = GamePhase.GRANDE)
         val decision = aiLogic.makeDecision(gameState, testPlayer.copy(hand = hand))
         assertTrue(decision.action is GameAction.Envido)
-        // `decideInitialBet` para strength alta usa rng.nextInt(2, 5) -> 2..4 aleatorio.
-        assertTrue((decision.action as GameAction.Envido).amount in 2..4)
+        assertTrue((decision.action as GameAction.Envido).amount in 3..5)
     }
 
     @Test

--- a/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
+++ b/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
@@ -1,5 +1,6 @@
 package com.doselfurioso.musvisto.logic
 
+import com.doselfurioso.musvisto.R
 import com.doselfurioso.musvisto.model.*
 import org.junit.Assert.*
 import org.junit.Before
@@ -84,6 +85,65 @@ class AILogicTest {
                 withPartnerMano is GameAction.Mus
             )
         }
+    }
+
+    // --- TESTS CAPITANÍA DE LANCE (#1/#4: rol de apoyo) ---
+
+    // ai (teamB) primero en turno, mano floja a Juego; compañero (teamB) actúa
+    // después y ha señalizado 31. ai debe apoyar: no abre (Paso) aunque la
+    // fuerza de equipo (fusionada) le empujaría a envidar.
+    @Test
+    fun `support - early weak AI defers to later partner who signaled Juego`() {
+        val hand = listOf(Card(Suit.OROS, Rank.REY), Card(Suit.COPAS, Rank.REY), Card(Suit.ESPADAS, Rank.CINCO), Card(Suit.BASTOS, Rank.CUATRO)) // sin juego (29)
+        val ai = testPlayer.copy(hand = hand) // teamB
+        val partner = Player(id = "ai2", name = "Compa", team = "teamB", avatarResId = 0, isAi = true)
+        val opp1 = Player(id = "p1", name = "Op1", team = "teamA", avatarResId = 0)
+        val opp2 = Player(id = "p2", name = "Op2", team = "teamA", avatarResId = 0)
+        val gameState = GameState(
+            players = listOf(ai, opp1, partner, opp2),
+            gamePhase = GamePhase.JUEGO,
+            manoPlayerId = ai.id, // ai pos 0 (más temprano), partner pos 2
+            knownGestures = mapOf(partner.id to ActiveGestureInfo(partner.id, R.drawable.sena_31))
+        )
+        val decision = aiLogic.makeDecision(gameState, ai)
+        assertTrue("En apoyo no debe abrir", decision.action is GameAction.Paso)
+    }
+
+    // Mismo escenario pero ai es el capitán (actúa DESPUÉS que el compañero):
+    // NO debe forzar apoyo; con la fuerza de equipo alta debe envidar.
+    @Test
+    fun `support - captain (later position) does NOT defer`() {
+        val hand = listOf(Card(Suit.OROS, Rank.REY), Card(Suit.COPAS, Rank.REY), Card(Suit.ESPADAS, Rank.CINCO), Card(Suit.BASTOS, Rank.CUATRO))
+        val ai = testPlayer.copy(hand = hand)
+        val partner = Player(id = "ai2", name = "Compa", team = "teamB", avatarResId = 0, isAi = true)
+        val opp1 = Player(id = "p1", name = "Op1", team = "teamA", avatarResId = 0)
+        val opp2 = Player(id = "p2", name = "Op2", team = "teamA", avatarResId = 0)
+        val gameState = GameState(
+            players = listOf(partner, opp1, ai, opp2),
+            gamePhase = GamePhase.JUEGO,
+            manoPlayerId = partner.id, // partner pos 0, ai pos 2 -> ai capitán
+            knownGestures = mapOf(partner.id to ActiveGestureInfo(partner.id, R.drawable.sena_31))
+        )
+        val decision = aiLogic.makeDecision(gameState, ai)
+        assertFalse("El capitán no juega de apoyo", decision.action is GameAction.Paso)
+    }
+
+    // ai con mano propia fuerte (31) no cede aunque esté en posición temprana.
+    @Test
+    fun `support - strong own hand does NOT defer even if early`() {
+        val hand = listOf(Card(Suit.OROS, Rank.REY), Card(Suit.COPAS, Rank.CABALLO), Card(Suit.ESPADAS, Rank.SOTA), Card(Suit.BASTOS, Rank.AS)) // 31
+        val ai = testPlayer.copy(hand = hand)
+        val partner = Player(id = "ai2", name = "Compa", team = "teamB", avatarResId = 0, isAi = true)
+        val opp1 = Player(id = "p1", name = "Op1", team = "teamA", avatarResId = 0)
+        val opp2 = Player(id = "p2", name = "Op2", team = "teamA", avatarResId = 0)
+        val gameState = GameState(
+            players = listOf(ai, opp1, partner, opp2),
+            gamePhase = GamePhase.JUEGO,
+            manoPlayerId = ai.id,
+            knownGestures = mapOf(partner.id to ActiveGestureInfo(partner.id, R.drawable.sena_31))
+        )
+        val decision = aiLogic.makeDecision(gameState, ai)
+        assertFalse("Mano propia fuerte no cede la iniciativa", decision.action is GameAction.Paso)
     }
 
     // --- NUEVOS TESTS DE DECISIONES DE LA IA ---

--- a/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
+++ b/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
@@ -146,6 +146,59 @@ class AILogicTest {
         assertFalse("Mano propia fuerte no cede la iniciativa", decision.action is GameAction.Paso)
     }
 
+    // --- TESTS 31 EN POSTRE ANTE ENVITE A JUEGO ---
+
+    private fun postre31JuegoState(betAmount: Int): Pair<GameState, Player> {
+        val hand = listOf(Card(Suit.OROS, Rank.REY), Card(Suit.COPAS, Rank.CABALLO), Card(Suit.ESPADAS, Rank.SOTA), Card(Suit.BASTOS, Rank.AS)) // 31
+        val ai = testPlayer.copy(hand = hand) // teamB
+        val partner = Player(id = "ai2", name = "Compa", team = "teamB", avatarResId = 0, isAi = true)
+        val opp1 = Player(id = "p1", name = "Op1", team = "teamA", avatarResId = 0)
+        val opp2 = Player(id = "p2", name = "Op2", team = "teamA", avatarResId = 0)
+        // Orden empezando en opp1 -> [opp1, partner, opp2, ai]: ai es postre.
+        val gs = GameState(
+            players = listOf(ai, opp1, partner, opp2),
+            gamePhase = GamePhase.JUEGO,
+            manoPlayerId = opp1.id,
+            currentBet = BetInfo(betAmount, opp1.id, ai.id)
+        )
+        return gs to ai
+    }
+
+    // Garantía de buen Mus: un envite pequeño con 31 (aunque sea postre)
+    // NUNCA se pliega — puede quererse o subirse (ambas correctas), pero
+    // jamás NoQuiero/Paso. Esto verifica que el fix anti-exploit no degrada
+    // el juego con la mejor jugada ante envites baratos.
+    @Test
+    fun `postre 31 never folds a small Juego bet`() {
+        val (gs, ai) = postre31JuegoState(betAmount = 2)
+        repeat(30) {
+            val action = aiLogic.makeDecision(gs, ai).action
+            assertFalse(
+                "31 no debe plegar un envite pequeño, fue $action",
+                action is GameAction.NoQuiero || action is GameAction.Paso
+            )
+        }
+    }
+
+    // Anti-exploit: ante un envite mayor, el 31 en postre NO acepta el 100%
+    // de las veces (no es farmeable de forma determinista) — pero tampoco
+    // pliega siempre (seguiría siendo buena mano).
+    @Test
+    fun `postre 31 facing a bigger Juego bet is not deterministic`() {
+        val (gs, ai) = postre31JuegoState(betAmount = 5)
+        var quiero = 0
+        var noQuiero = 0
+        repeat(200) {
+            when (aiLogic.makeDecision(gs, ai).action) {
+                is GameAction.Quiero -> quiero++
+                is GameAction.NoQuiero -> noQuiero++
+                else -> {}
+            }
+        }
+        assertTrue("Debe querer la mayoría de las veces", quiero > 0)
+        assertTrue("No debe ser determinista (a veces no quiere)", noQuiero > 0)
+    }
+
     // --- NUEVOS TESTS DE DECISIONES DE LA IA ---
 
     @Test


### PR DESCRIPTION
## Contexto

Tanda hacia el hito "partida completa con buena sensación". Cambios de comportamiento de IA detectados en playtest + mejoras de tooling de debug. Todo con tests unitarios deterministas; suite verde.

## Cambios

**Comportamiento de IA (`AILogic`):**
- **#2 Valor de Juego:** curva recalibrada (32: 85→70, resto bajado y separado; 31 sigue premium) + penalización por posición para juegos 32-40 (postre pierde desempates).
- **#3 Importe de envite:** `betAmount(strength)` sesga el importe por fuerza de mano (≥90→4-5 … resto→2-3); faroles baratos. Sustituye los `rng.nextInt(2,5)` planos.
- **#5 No quitar mano al compañero:** `decideMus` recibe `gameState`; si el compañero es mano, sube los umbrales de corte (no corta con mano normalita).
- **#1/#4 Capitanía de lance por posición:** `shouldPlaySupport` — si el compañero señalizó fuerza y actúa después (mejor posición) y mi mano propia es floja, juego de apoyo (no abro / no subo) para no pisarle. No toca `decideInitialBet/decideResponse/decideMus`.
- **Fix 31 en postre:** el 31 sin ser mano pasa de penalización plana a graduada por posición; `decideResponse` deja de aceptar Juego de forma 100% determinista ante envites grandes (anti-exploit), pero sigue queriendo envites pequeños (Mus correcto).

**Tooling de debug:**
- Log de decisiones más legible: cartas sin palo + mano ordenada, línea TL;DR al inicio, líneas duplicadas de Juego fusionadas, lance en juego resaltado, marcador desde la perspectiva de la IA.
- `fix(debug)`: `navigationBarsPadding()` en el panel de AI logs (ya no lo tapaba la barra de navegación).

## Verificación

- `gradlew testDebugUnitTest` verde (47 tests, incluidos los nuevos deterministas de #5, capitanía y 31-postre).
- `gradlew assembleDebug` verde.
- Validado en playtest por el usuario; reglas del Mus revisadas (orden de Juego, desempate por mano, capitanía estrategia no-regla).