### PR TITLE
fix(ai): la defensa de señas también considera Grande/Chica (#9)

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -945,20 +945,21 @@ class AILogic constructor(
                 }
 
                 // #9: una seña rival de reyes/ases/duples/31 también implica
-                // fuerza del rival en Grande/Chica, no solo Pares/Juego. Bajar
-                // mi confianza ahí, proporcional a la fuerza implícita (mitad
-                // del boost que esa seña daría al equipo que la posee).
+                // fuerza del rival en Grande/Chica, no solo Pares/Juego. Solo
+                // bajo mi confianza si esa fuerza implícita SUPERA mi propia
+                // mano en ese lance (igual que la rama de Pares): con 4 reyes
+                // no me asusta una seña de 3 reyes. Reducción = mitad del boost.
                 val oppG = partnerGrandeBoost(gesture.gestureResId)
                 val oppC = partnerChicaBoost(gesture.gestureResId)
-                if (oppG > 0) {
+                if (oppG > baseStrength.grande) {
                     val g = (finalAdjustedStrength.grande - oppG / 2).coerceIn(0, 100)
                     finalAdjustedStrength = finalAdjustedStrength.copy(grande = g)
-                    logBuilder.appendLine("     -> Rival fuerte en Grande (seña): mi Grande -> $g")
+                    logBuilder.appendLine("     -> Rival más fuerte en Grande (seña $oppG > mi ${baseStrength.grande}): mi Grande -> $g")
                 }
-                if (oppC > 0) {
+                if (oppC > baseStrength.chica) {
                     val c = (finalAdjustedStrength.chica - oppC / 2).coerceIn(0, 100)
                     finalAdjustedStrength = finalAdjustedStrength.copy(chica = c)
-                    logBuilder.appendLine("     -> Rival fuerte en Chica (seña): mi Chica -> $c")
+                    logBuilder.appendLine("     -> Rival más fuerte en Chica (seña $oppC > mi ${baseStrength.chica}): mi Chica -> $c")
                 }
             }
         }

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -943,6 +943,23 @@ class AILogic constructor(
                     }
                     else -> {}
                 }
+
+                // #9: una seña rival de reyes/ases/duples/31 también implica
+                // fuerza del rival en Grande/Chica, no solo Pares/Juego. Bajar
+                // mi confianza ahí, proporcional a la fuerza implícita (mitad
+                // del boost que esa seña daría al equipo que la posee).
+                val oppG = partnerGrandeBoost(gesture.gestureResId)
+                val oppC = partnerChicaBoost(gesture.gestureResId)
+                if (oppG > 0) {
+                    val g = (finalAdjustedStrength.grande - oppG / 2).coerceIn(0, 100)
+                    finalAdjustedStrength = finalAdjustedStrength.copy(grande = g)
+                    logBuilder.appendLine("     -> Rival fuerte en Grande (seña): mi Grande -> $g")
+                }
+                if (oppC > 0) {
+                    val c = (finalAdjustedStrength.chica - oppC / 2).coerceIn(0, 100)
+                    finalAdjustedStrength = finalAdjustedStrength.copy(chica = c)
+                    logBuilder.appendLine("     -> Rival fuerte en Chica (seña): mi Chica -> $c")
+                }
             }
         }
 


### PR DESCRIPTION
## Contexto

Reportado en playtest: al pasar seña de "3 reyes" al compañero, el rival la detecta y ajusta su jugada de Pares pero NO la de Grande (3 reyes domina Grande).

## Causa

El bloque defensivo de `adjustStrengthsBasedOnKnownGestures` solo reducía Pares/Juego ante una seña rival; ignoraba que reyes/ases/duples/31 también implican fuerza del rival en Grande/Chica. El lado ofensivo (compañero) sí lo hacía vía `partnerGrandeBoost`/`partnerChicaBoost`.

## Cambio

Tras el `when` defensivo, reduce mi confianza en Grande/Chica proporcional a la fuerza implícita de la seña (mitad del boost), **solo si esa fuerza supera mi propia mano en ese lance** (mismo guard que la rama de Pares: con 4 reyes no me asusta una seña rival de 3 reyes). Respeta el gate del #7 (solo si la seña fue interceptada).

## Verificación

- `gradlew testDebugUnitTest` verde.
- Simulador (200 partidas): sin regresión estructural — lances siguen disputados (envido-showdown 74%), 31-postre no determinista, aceptaciones ~52%. Es un fix de correctitud; el feel se confirma en playtest.