### PR TITLE
fix(ai): #25 eliminar órdago de cierre con mano floja yendo por delante

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -399,10 +399,12 @@ class AILogic constructor(
         if (opponentScore >= 30 && strength > 80 && scoreDifference < -10) {
             return Pair(GameAction.Órdago, "Reason: Block opponent win (opp $opponentScore, diff $scoreDifference, strength $strength)")
         }
-        // 3) Cerrar partida: estamos a un envite de ganar nosotros con mano decente.
-        if (myTeamScore >= 35 && opponentScore < 35 && strength > 50) {
-            return Pair(GameAction.Órdago, "Reason: Closing the game (my $myTeamScore, opp $opponentScore, strength $strength)")
-        }
+        // (Antes había una condición 3 "cerrar partida" con strength > 50:
+        // regalaba el chico yendo por delante con mano floja —ordagar 36-29 sin
+        // nada— porque jugando valor normal se cierra igual sin downside
+        // catastrófico. Eliminada (#25). El órdago de cierre legítimo (filo
+        // mutuo cerca de 40, casi la nuts) se diseñará junto a #16 como módulo
+        // de endgame, no como parche aquí.)
 
         // --- APERTURA POR BANDAS CON CONTEXTO (farol / valor controlado) ---
         // Antes solo abría con casi la nuts (>80): los lances morían a paso.


### PR DESCRIPTION
## Problema (#25, playtest)

Yendo 36-29 (ganando), el compañero IA metía órdago a Grande "sin llevar nada": regalaba el chico. Causa: condición 3 de órdago proactivo en `decideInitialBet`,

```
if (myTeamScore >= 35 && opponentScore < 35 && strength > 50) -> Órdago
```

`strength > 50` (mano casi a la par) stakea la partida entera cuando jugando valor normal se cierra igual sin downside catastrófico. Listón 30 puntos más bajo que las condiciones hermanas (1: >75, 2: >80), siendo la que más caro paga al fallar.

## Cambio

Eliminada la condición 3 (Candidato A). El órdago de cierre legítimo (filo mutuo cerca de 40, casi la nuts, con factor mano) se diseñará junto a #16 como módulo de endgame, no como parche aquí.

## Validación

Simulador determinista, 200 partidas sembradas (baseline vs post-fix):

- Órdago acciones 328 → 140; partidas con órdago 19 → 3 (desaparece el espurio).
- %win de aceptar (51.7→51.1) y showdown de envites abiertos (74.0→74.5) estables → no introduce envites malos nuevos.
- Tantos netos al aceptar −141 → −206: artefacto del #1 (la IA rival es demasiado tímida y rechaza el órdago, dándolo como tantos-gratis; al quitarlo, ese volumen pasa a la senda de envite ya deficitaria). El simulador no puede ver la catástrofe que el fix evita (rival que ACEPTA y gana el chico) porque el rival del sim casi nunca acepta. Límite estructural conocido del simulador → validación final por playtest.