### PR TITLE
fix(ui): #27 anuncios por recencia (seq) — arregla parpadeo en cambio de lance

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -799,11 +799,18 @@ fun ActionAnnouncement(
     dimens: ResponsiveDimens
 ) {
     // El game state declara QUÉ anuncio quiere mostrar; el composable decide CUÁNDO y CÓMO.
-    // transientAction (la acción que cerró el lance) tiene prioridad sobre la persistente.
-    val targetAction: LastActionInfo? = when {
-        gameState.transientAction?.playerId == player.id -> gameState.transientAction
-        else -> gameState.currentLanceActions[player.id]
-    }
+    // Elegimos por RECENCIA (LastActionInfo.seq, único por instancia) entre la
+    // acción que cerró el lance (transientAction) y la del lance actual
+    // (currentLanceActions). Antes transientAction tenía prioridad absoluta:
+    // el jugador que cerraba un lance Y hablaba primero en el siguiente (la
+    // mano) seguía mostrando la acción VIEJA hasta que el borrado asíncrono
+    // anulaba transientAction, y entonces saltaba a la nueva → parpadeo
+    // viejo↔nuevo (#27 / KNOWN_ISSUES). Por seq nunca se muestra la vieja si
+    // ya hay una más reciente, sin depender del timing del borrado.
+    val transient = gameState.transientAction?.takeIf { it.playerId == player.id }
+    val persistent = gameState.currentLanceActions[player.id]
+    val targetAction: LastActionInfo? =
+        listOfNotNull(transient, persistent).maxByOrNull { it.seq }
 
     var displayedAction by remember { mutableStateOf<LastActionInfo?>(null) }
     var shownAt by remember { mutableStateOf(0L) }


### PR DESCRIPTION
## Problema (#27, también KNOWN_ISSUES L11)

Al cambiar de lance a PARES/JUEGO con una IA de mano, los ActionAnnouncements parpadeaban mostrando alternativamente la acción anterior y la actual ("no se entiende nada").

## Causa raíz

`targetAction` daba **prioridad absoluta a `transientAction`** (la acción que cerró el lance) sobre `currentLanceActions[player]`. El jugador que cerraba un lance y hablaba primero en el siguiente (la mano) seguía mostrando la acción VIEJA hasta que el borrado asíncrono del ViewModel (1200ms, que compite con la declaración) anulaba `transientAction`; ahí saltaba a la nueva → toggle viejo↔nuevo.

## Fix

Elegir por **recencia** usando `LastActionInfo.seq` (que existe justo como anti-parpadeo):
```
val transient = gameState.transientAction?.takeIf { it.playerId == player.id }
val persistent = gameState.currentLanceActions[player.id]
val targetAction = listOfNotNull(transient, persistent).maxByOrNull { it.seq }
```
La acción nueva gana en cuanto entra, sin depender del timing del borrado. No toca `seq`, ni el ViewModel, ni la máquina de estados del composable (decisiones técnicas de KNOWN_ISSUES respetadas).

## Verificación

- Compila + suite unitaria verde.
- Auditado con `compose-ui-reviewer`: sólido, ataca la causa raíz, **igual o menos** reinicios de `LaunchedEffect` (reusa instancias existentes, no crea identidades nuevas), degradación segura ante colisión teórica de `seq`. Respeta KNOWN_ISSUES.
- **Pendiente: verificación visual en playtest** (el parpadeo es timing visual, no cubrible por tests). Revalidar también KNOWN_ISSUES L11 (mano = jugador derecho, Chica→PARES_CHECK): probablemente cerrado de paso.

No mergear hasta verificación visual.