### PR TITLE
fix(ui): #27 rehacer sistema de anuncios — fuente única, sin carrera de timing

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/logic/MusGameLogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/MusGameLogic.kt
@@ -270,16 +270,18 @@ class MusGameLogic constructor(private val random: Random){
 
         // ---- FINALIZACIÓN Y GESTIÓN DE ANUNCIOS ----
         // `currentLanceActions` es la ÚNICA fuente de verdad de los anuncios:
-        // mapa jugador→última acción del lance EN CURSO. Mutado solo de forma
-        // síncrona aquí (sin limpieza asíncrona en el ViewModel, sin campo
-        // transient), de modo que cada `ActionAnnouncement` observe un único
-        // valor monótono y no haya carrera de timing entre capas (#27).
+        // mapa jugador→última acción del lance. Mutado solo de forma SÍNCRONA
+        // (aquí, acumulando por jugador; y el ViewModel lo vacía de golpe en
+        // la frontera de lance, sin campo transient ni filterNot parcial), de
+        // modo que cada `ActionAnnouncement` observe un único valor monótono
+        // y no haya carrera de timing entre capas (#27).
         //
-        // Si esta acción CIERRA el lance (cambia de fase), el lance nuevo
-        // arranca con SOLO la acción que lo cerró: así el que cierra mantiene
-        // su anuncio visible y a los demás se les vacía el target de golpe
-        // (su composable lo retiene su mínimo y se desvanece limpio). En el
-        // mismo lance, acumulamos por jugador.
+        // PERSISTENCIA dentro del lance: la acción de cada jugador queda
+        // visible hasta que el lance se resuelve (el jugador llega a su turno
+        // sabiendo a qué responde). NO se reduce al cerrar lance: se conservan
+        // TODAS las acciones del lance cerrado durante el beat de ritmo del
+        // ViewModel (lance resuelto legible) y este las vacía juntas antes de
+        // la primera acción del lance nuevo.
         //
         // Un Envido sobre un envite ya existente es una SUBIDA: guardamos el
         // importe previo (no nulo ⇒ subida) para que el anuncio diga "N más"
@@ -289,13 +291,8 @@ class MusGameLogic constructor(private val random: Random){
         } else {
             LastActionInfo(playerId, action)
         }
-        val phaseChanged = currentState.gamePhase != nextState.gamePhase
 
-        val updatedLanceActions = if (phaseChanged) {
-            mapOf(playerId to newActionInfo)
-        } else {
-            currentState.currentLanceActions + (playerId to newActionInfo)
-        }
+        val updatedLanceActions = currentState.currentLanceActions + (playerId to newActionInfo)
 
         return nextState.copy(
             lastAction = newActionInfo,

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/MusGameLogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/MusGameLogic.kt
@@ -473,7 +473,11 @@ class MusGameLogic constructor(private val random: Random){
             gamePhase = GamePhase.GRANDE,
             availableActions = listOf(GameAction.Paso, GameAction.Envido(2), GameAction.Órdago),
             playersWhoPassed = emptySet(),
-            discardCounts = emptyMap(),
+            // NO vaciamos discardCounts aquí: debe sobrevivir todo el resto de
+            // la ronda para que el indicador de descarte del avatar diga
+            // cuántas cartas tomó cada jugador. Se resetea solo en el reparto
+            // de la ronda siguiente (startNewRound construye un GameState nuevo
+            // con discardCounts por defecto vacío).
             currentBet = null,
             currentTurnPlayerId = currentState.manoPlayerId,
             isNewLance = true,

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/MusGameLogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/MusGameLogic.kt
@@ -269,10 +269,18 @@ class MusGameLogic constructor(private val random: Random){
         if (nextState == currentState) return currentState
 
         // ---- FINALIZACIÓN Y GESTIÓN DE ANUNCIOS ----
-        // Mantenemos TODOS los anuncios del lance en el mapa para que coexistan en
-        // pantalla. El ViewModel limpia el mapa tras el tiempo mínimo visible,
-        // justo antes de iniciar el siguiente lance (no aquí, para no borrar de
-        // golpe los anuncios de los demás cuando el último jugador cierra el lance).
+        // `currentLanceActions` es la ÚNICA fuente de verdad de los anuncios:
+        // mapa jugador→última acción del lance EN CURSO. Mutado solo de forma
+        // síncrona aquí (sin limpieza asíncrona en el ViewModel, sin campo
+        // transient), de modo que cada `ActionAnnouncement` observe un único
+        // valor monótono y no haya carrera de timing entre capas (#27).
+        //
+        // Si esta acción CIERRA el lance (cambia de fase), el lance nuevo
+        // arranca con SOLO la acción que lo cerró: así el que cierra mantiene
+        // su anuncio visible y a los demás se les vacía el target de golpe
+        // (su composable lo retiene su mínimo y se desvanece limpio). En el
+        // mismo lance, acumulamos por jugador.
+        //
         // Un Envido sobre un envite ya existente es una SUBIDA: guardamos el
         // importe previo (no nulo ⇒ subida) para que el anuncio diga "N más"
         // en vez de "Envido N" (#18).
@@ -283,13 +291,16 @@ class MusGameLogic constructor(private val random: Random){
         }
         val phaseChanged = currentState.gamePhase != nextState.gamePhase
 
-        val updatedLanceActions = currentState.currentLanceActions + (playerId to newActionInfo)
+        val updatedLanceActions = if (phaseChanged) {
+            mapOf(playerId to newActionInfo)
+        } else {
+            currentState.currentLanceActions + (playerId to newActionInfo)
+        }
 
         return nextState.copy(
             lastAction = newActionInfo,
             actionLog = (nextState.actionLog + newActionInfo).takeLast(4),
-            currentLanceActions = updatedLanceActions,
-            transientAction = if (phaseChanged) newActionInfo else null
+            currentLanceActions = updatedLanceActions
         )
     }
 

--- a/app/src/main/java/com/doselfurioso/musvisto/model/GameState.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/model/GameState.kt
@@ -38,7 +38,6 @@ data class GameState(
     val noMusPlayer: String? = null,
     val isNewLance: Boolean = true,
     @Transient val currentLanceActions: Map<String, LastActionInfo> = emptyMap(),
-    @Transient val transientAction: LastActionInfo? = null,
     val scoreBreakdown: ScoreBreakdown? = null,
     val scoreEvents: List<ScoreEventInfo> = emptyList(),
     val ordagoInfo: OrdagoInfo? = null,

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -74,12 +74,6 @@ import com.doselfurioso.musvisto.debug.DebugFeatures
 import com.doselfurioso.musvisto.model.Card as CardData
 
 internal const val ANNOUNCEMENT_MIN_VISIBLE_MS = 1200L
-// Techo de visibilidad: pasado este tiempo el anuncio se desvanece SOLO,
-// aunque nadie lo reemplace. Simétrico para todos los jugadores y puramente
-// local del composable (sin acoplar al ViewModel). Resuelve que la acción del
-// que CIERRA el lance se quedara colgada hasta que le volviera el turno (su
-// targetAction nunca pasaba a null; ver rework #27).
-private const val ANNOUNCEMENT_MAX_VISIBLE_MS = 2000L
 // Piso corto cuando el anuncio es REEMPLAZADO por otra acción (no ocultado):
 // basta un golpe de vista + cross-fade. Evita que la acción anterior del propio
 // jugador se quede colgada cuando actúa muy rápido (p. ej. No Mus -> Paso).
@@ -832,12 +826,6 @@ fun ActionAnnouncement(
                 }
                 displayedAction = targetAction
                 shownAt = System.currentTimeMillis()
-                // Auto-expiración: si nadie lo reemplaza ni lo oculta, se
-                // desvanece solo pasado el techo. Esta misma corrutina del
-                // LaunchedEffect se cancela si llega un targetAction nuevo
-                // (re-key), así que un reemplazo cancela este auto-ocultado.
-                delay(ANNOUNCEMENT_MAX_VISIBLE_MS)
-                displayedAction = null
             }
             targetAction == null && displayedAction != null -> {
                 val remaining = ANNOUNCEMENT_MIN_VISIBLE_MS - (now - shownAt)

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -806,12 +806,12 @@ fun ActionAnnouncement(
     gameState: GameState,
     dimens: ResponsiveDimens
 ) {
-    // El game state declara QUÉ anuncio quiere mostrar; el composable decide CUÁNDO y CÓMO.
-    // transientAction (la acción que cerró el lance) tiene prioridad sobre la persistente.
-    val targetAction: LastActionInfo? = when {
-        gameState.transientAction?.playerId == player.id -> gameState.transientAction
-        else -> gameState.currentLanceActions[player.id]
-    }
+    // El game state declara QUÉ anuncio quiere mostrar; el composable decide
+    // CUÁNDO y CÓMO. Fuente ÚNICA: currentLanceActions[player] (la lógica la
+    // muta solo de forma síncrona). Un único valor monótono por jugador ⇒ sin
+    // carrera viejo↔nuevo (#27). El mínimo visible y el desvanecido al quedar
+    // null los gestiona el LaunchedEffect de abajo, en local.
+    val targetAction: LastActionInfo? = gameState.currentLanceActions[player.id]
 
     var displayedAction by remember { mutableStateOf<LastActionInfo?>(null) }
     var shownAt by remember { mutableStateOf(0L) }

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -74,6 +74,12 @@ import com.doselfurioso.musvisto.debug.DebugFeatures
 import com.doselfurioso.musvisto.model.Card as CardData
 
 internal const val ANNOUNCEMENT_MIN_VISIBLE_MS = 1200L
+// Techo de visibilidad: pasado este tiempo el anuncio se desvanece SOLO,
+// aunque nadie lo reemplace. Simétrico para todos los jugadores y puramente
+// local del composable (sin acoplar al ViewModel). Resuelve que la acción del
+// que CIERRA el lance se quedara colgada hasta que le volviera el turno (su
+// targetAction nunca pasaba a null; ver rework #27).
+private const val ANNOUNCEMENT_MAX_VISIBLE_MS = 2000L
 // Piso corto cuando el anuncio es REEMPLAZADO por otra acción (no ocultado):
 // basta un golpe de vista + cross-fade. Evita que la acción anterior del propio
 // jugador se quede colgada cuando actúa muy rápido (p. ej. No Mus -> Paso).
@@ -826,6 +832,12 @@ fun ActionAnnouncement(
                 }
                 displayedAction = targetAction
                 shownAt = System.currentTimeMillis()
+                // Auto-expiración: si nadie lo reemplaza ni lo oculta, se
+                // desvanece solo pasado el techo. Esta misma corrutina del
+                // LaunchedEffect se cancela si llega un targetAction nuevo
+                // (re-key), así que un reemplazo cancela este auto-ocultado.
+                delay(ANNOUNCEMENT_MAX_VISIBLE_MS)
+                displayedAction = null
             }
             targetAction == null && displayedAction != null -> {
                 val remaining = ANNOUNCEMENT_MIN_VISIBLE_MS - (now - shownAt)

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -711,6 +711,7 @@ private fun PlayerAvatar(
     isMano: Boolean,
     hasCutMus: Boolean,
     activeGestureResId: Int?,
+    discardCount: Int? = null,
     dimens: ResponsiveDimens
 ) {
     val borderColor = if (isCurrentTurn) Color.Yellow else Color.Transparent
@@ -772,6 +773,35 @@ private fun PlayerAvatar(
                     .background(Color.Black.copy(alpha = 0.6f), CircleShape)
                     .padding(4.dp)
             )
+        }
+
+        // Indicador PERSISTENTE de descarte: cuántas cartas cambió este
+        // jugador en el Mus. Vive toda la ronda (discardCounts no se vacía
+        // hasta el reparto siguiente), por eso es un badge del avatar y no
+        // una burbuja de anuncio (esas se limpian por lance). Esquina libre
+        // (mano = abajo-dcha, corta-mus = abajo-izda, seña = centro).
+        if (discardCount != null && discardCount > 0) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .background(Color.Black.copy(alpha = 0.6f), CircleShape)
+                    .padding(horizontal = 5.dp, vertical = 3.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_cycle),
+                    contentDescription = "Cartas descartadas",
+                    tint = Color.White,
+                    modifier = Modifier.size(dimens.avatarSize / 5)
+                )
+                Text(
+                    text = "$discardCount",
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = dimens.fontSizeMedium,
+                    modifier = Modifier.padding(start = 2.dp)
+                )
+            }
         }
     }
 }
@@ -1025,7 +1055,8 @@ fun VerticalPlayerArea(
             isCurrentTurn = isCurrentTurn,
             isMano = isMano, hasCutMus = hasCutMus,
             dimens = dimens,
-            activeGestureResId = if (activeGesture?.playerId == player.id) activeGesture.gestureResId else null,)
+            activeGestureResId = if (activeGesture?.playerId == player.id) activeGesture.gestureResId else null,
+            discardCount = gameState.discardCounts[player.id])
         handContent()
     }
 }
@@ -1066,7 +1097,7 @@ fun HorizontalPlayerArea(
                     ActionAnnouncement(player = player, gameState = gameState, dimens = dimens)
                 }
             }
-            PlayerAvatar(player = player, isCurrentTurn = isCurrentTurn, isMano = isMano, hasCutMus = hasCutMus, dimens = dimens, activeGestureResId = if (activeGesture?.playerId == player.id) activeGesture.gestureResId else null)
+            PlayerAvatar(player = player, isCurrentTurn = isCurrentTurn, isMano = isMano, hasCutMus = hasCutMus, dimens = dimens, activeGestureResId = if (activeGesture?.playerId == player.id) activeGesture.gestureResId else null, discardCount = gameState.discardCounts[player.id])
             if (!announcementAbove) {
                 Box(
                     modifier = Modifier.layout { measurable, constraints ->

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
@@ -366,32 +366,17 @@ class GameViewModel constructor(
 
         // Lanzamos una corrutina para gestionar la secuencia de forma ordenada
         viewModelScope.launch {
-            // Si la fase ha cambiado, damos al composable ActionAnnouncement el
-            // tiempo mínimo visible para mostrar la acción que cerró el lance
-            // (y mantener visibles los anuncios de los demás jugadores). Pasado
-            // ese tiempo, limpiamos el estado de anuncios ANTES de continuar para
-            // que el siguiente lance no arrastre nada. Cada composable aplica su
-            // propia animación de salida respetando su mínimo individual.
+            // Si la fase ha cambiado (lance cerrado), pausamos para que la
+            // acción que cerró el lance sea legible antes de que la IA entre
+            // al siguiente. SOLO ritmo: NO mutamos el estado de anuncios. La
+            // limpieza la hace ya la lógica de forma síncrona (el lance nuevo
+            // arranca con solo la acción de cierre) y cada ActionAnnouncement
+            // gestiona su mínimo visible y su desvanecido localmente. Sin
+            // mutación asíncrona aquí no hay carrera de timing → sin parpadeo
+            // (#27).
             if (phaseChanged) {
-                // Capturamos los anuncios del lance que acaba de cerrar ANTES de
-                // esperar. Tras el tiempo mínimo solo eliminamos esas instancias
-                // concretas: si el jugador ya actuó en el lance nuevo, su nueva
-                // acción tiene otro `seq` (LastActionInfo.seq es único por
-                // instancia) y NO se borra, aunque sea la misma acción repetida.
-                val staleActions = _gameState.value.currentLanceActions
-                val staleTransient = _gameState.value.transientAction
                 delay(ANNOUNCEMENT_MIN_VISIBLE_MS)
                 awaitNotPaused()
-                val current = _gameState.value
-                _gameState.value = current.copy(
-                    currentLanceActions = current.currentLanceActions
-                        .filterNot { (id, info) -> staleActions[id] == info },
-                    transientAction = if (current.transientAction == staleTransient) {
-                        null
-                    } else {
-                        current.transientAction
-                    }
-                )
             }
 
             // Continuamos con el lance actual.

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
@@ -366,17 +366,20 @@ class GameViewModel constructor(
 
         // Lanzamos una corrutina para gestionar la secuencia de forma ordenada
         viewModelScope.launch {
-            // Si la fase ha cambiado (lance cerrado), pausamos para que la
-            // acción que cerró el lance sea legible antes de que la IA entre
-            // al siguiente. SOLO ritmo: NO mutamos el estado de anuncios. La
-            // limpieza la hace ya la lógica de forma síncrona (el lance nuevo
-            // arranca con solo la acción de cierre) y cada ActionAnnouncement
-            // gestiona su mínimo visible y su desvanecido localmente. Sin
-            // mutación asíncrona aquí no hay carrera de timing → sin parpadeo
-            // (#27).
+            // Frontera de lance. Durante este beat se mantienen visibles
+            // TODAS las acciones del lance que acaba de cerrar (incl. la de
+            // cierre) para que el jugador lea el lance resuelto sin perderse
+            // qué hizo la IA. Pasado el beat, vaciamos `currentLanceActions`
+            // de UNA SOLA VEZ y de forma SÍNCRONA, ANTES de que arranque la
+            // primera acción del lance nuevo: fuente única, sin campo
+            // transient, sin acción nueva concurrente ⇒ el toggle viejo↔nuevo
+            // de #27 es imposible. Cada ActionAnnouncement ya superó su mínimo
+            // visible durante el beat, así que su target→null se desvanece
+            // limpio y sincronizado.
             if (phaseChanged) {
                 delay(ANNOUNCEMENT_MIN_VISIBLE_MS)
                 awaitNotPaused()
+                _gameState.value = _gameState.value.copy(currentLanceActions = emptyMap())
             }
 
             // Continuamos con el lance actual.


### PR DESCRIPTION
@
## Por qué

PR #22 (`fix/announcement-flicker`, elegir `targetAction` por `seq`) se ve algo mejor pero **sigue dando problemas** en playtest. La causa no es la elección del valor: es **arquitectural**. El ciclo de vida del anuncio estaba partido en 3 capas con timing acoplado que compiten:

1. `GameState.transientAction` (acción que cerró el lance) vs `currentLanceActions` — dualidad cuya precedencia dependía del timing.
2. `GameViewModel`: limpieza **asíncrona** (`delay(MIN_VISIBLE)` + `filterNot` de stale) que muta el estado de anuncios mientras el composable anima.
3. `ActionAnnouncement`: timers locales (min visible / min before replace).

Cuando (1)+(2) corren contra (3) → toggle viejo↔nuevo (#27: "los anuncios se vuelven locos" al entrar a Pares/Juego con IA mano).

## Qué (rediseño = simplificación)

Una **sola fuente de verdad**, mutada solo de forma **síncrona**:

- Elimina el campo `GameState.transientAction` y todos sus usos.
- `currentLanceActions` es la única fuente. Al cerrar lance (cambio de fase) el lance nuevo arranca con **solo la acción de cierre**: el que cierra mantiene su anuncio; a los demás se les vacía el target de golpe y su composable lo retiene su mínimo y se desvanece limpio.
- Quita la limpieza asíncrona del ViewModel. Queda solo una pausa de **ritmo** en cambio de fase (sin mutar estado de anuncios) para que la acción de cierre sea legible.
- `ActionAnnouncement` observa un único valor monótono por jugador → no hay carrera, no hay toggle. El mínimo visible y el desvanecido siguen siendo locales del composable.

Neto: −37/+32 líneas, 4 ficheros. Sin campo transient, sin `filterNot` asíncrono, sin precedencia dependiente de timing.

## Validación

- `compileDebugKotlin` + `testDebugUnitTest` **verde**.
- El simulador es **ciego** a esto (no toca IA; es feel/UI) → la validación real es **playtest visual en emulador**: entrar a Pares/Juego con la IA de mano y comprobar que no parpadea.

Cierra #27 (y probablemente KNOWN_ISSUES L11). **No mergear sin tu verificación visual.**
@