### PR TITLE
feat(debug): modo escenario + editor in-app para forzar situaciones

### DIFF
--- a/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
+++ b/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
@@ -108,8 +108,9 @@ object DebugFeatures {
             ScenarioPanel(
                 onPlay = { viewModel.startScenario(it) },
                 modifier = Modifier
-                    .align(Alignment.TopCenter)
+                    .align(Alignment.BottomCenter)
                     .padding(8.dp)
+                    .navigationBarsPadding()
             )
         }
     }

--- a/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
+++ b/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
@@ -33,6 +33,10 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.doselfurioso.musvisto.model.Card
+import com.doselfurioso.musvisto.model.DebugScenario
+import com.doselfurioso.musvisto.model.Rank
+import com.doselfurioso.musvisto.model.Suit
 import com.doselfurioso.musvisto.presentation.GameViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -83,6 +87,121 @@ object DebugFeatures {
             Text(text = if (isDebugMode) "🐛 Debug: ON" else "🐛 Debug: OFF")
         }
     }
+
+    /**
+     * Overlay con la lista de escenarios de prueba. Tocando uno se reparten
+     * sus manos forzadas y la partida arranca en ese punto. Solo visible con
+     * el modo debug activado.
+     */
+    @Composable
+    fun ScenarioSelectorOverlay(viewModel: GameViewModel) {
+        val isDebugMode by viewModel.isDebugMode.collectAsState()
+        if (!isDebugMode) return
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .navigationBarsPadding()
+        ) {
+            ScenarioPanel(
+                onPick = { viewModel.startScenario(it) },
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(8.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScenarioPanel(onPick: (DebugScenario) -> Unit, modifier: Modifier = Modifier) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier.padding(4.dp),
+        horizontalAlignment = Alignment.Start
+    ) {
+        Box(
+            modifier = Modifier
+                .background(Color.Black.copy(alpha = 0.75f), RoundedCornerShape(8.dp))
+                .clickable { expanded = !expanded }
+                .padding(horizontal = 10.dp, vertical = 4.dp)
+        ) {
+            Text(
+                text = if (expanded) "▼ Escenarios" else "▲ Escenarios",
+                color = Color(0xFFFFD24A),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+
+        if (expanded) {
+            LazyColumn(
+                modifier = Modifier
+                    .width(260.dp)
+                    .heightIn(max = 360.dp)
+                    .padding(vertical = 4.dp)
+                    .background(Color.Black.copy(alpha = 0.88f), RoundedCornerShape(8.dp))
+                    .padding(8.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                items(DebugScenarios.all) { scenario ->
+                    Box(
+                        modifier = Modifier
+                            .background(Color(0xFF5D4037).copy(alpha = 0.9f), RoundedCornerShape(6.dp))
+                            .clickable {
+                                expanded = false
+                                onPick(scenario)
+                            }
+                            .padding(horizontal = 10.dp, vertical = 6.dp)
+                    ) {
+                        Text(
+                            text = scenario.name,
+                            color = Color.White,
+                            fontSize = 11.sp,
+                            lineHeight = 14.sp
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Catálogo de escenarios de prueba. Añade aquí los casos que quieras forzar:
+ * 4 cartas por jugador, sin repetir cartas entre manos. `manoId` decide quién
+ * es mano; con `startAtMus = true` la partida arranca en MUS (probar
+ * corte/descarte), si no aterriza en GRANDE con las manos intactas.
+ *
+ * Recuerda: Rey≡Tres y As≡Dos para pares y puntuación. "p1" = humano,
+ * "p3" = tu pareja, "p2"/"p4" = rivales.
+ */
+object DebugScenarios {
+    private fun c(suit: Suit, rank: Rank) = Card(suit, rank)
+
+    val all: List<DebugScenario> = listOf(
+        DebugScenario(
+            name = "Duples reyes (p1) vs duples cincos (p2)",
+            hands = mapOf(
+                "p1" to listOf(c(Suit.OROS, Rank.REY), c(Suit.OROS, Rank.CABALLO), c(Suit.COPAS, Rank.CABALLO), c(Suit.OROS, Rank.AS)),
+                "p2" to listOf(c(Suit.COPAS, Rank.REY), c(Suit.BASTOS, Rank.REY), c(Suit.COPAS, Rank.CINCO), c(Suit.ESPADAS, Rank.CINCO)),
+                "p3" to listOf(c(Suit.OROS, Rank.REY), c(Suit.ESPADAS, Rank.CABALLO), c(Suit.OROS, Rank.SOTA), c(Suit.OROS, Rank.CUATRO)),
+                "p4" to listOf(c(Suit.BASTOS, Rank.CABALLO), c(Suit.BASTOS, Rank.CUATRO), c(Suit.BASTOS, Rank.AS), c(Suit.ESPADAS, Rank.AS))
+            ),
+            manoId = "p1"
+        ),
+        DebugScenario(
+            name = "p1 mano con 31 de Juego",
+            hands = mapOf(
+                "p1" to listOf(c(Suit.OROS, Rank.REY), c(Suit.COPAS, Rank.SOTA), c(Suit.BASTOS, Rank.AS), c(Suit.ESPADAS, Rank.AS)),
+                "p2" to listOf(c(Suit.COPAS, Rank.REY), c(Suit.COPAS, Rank.CABALLO), c(Suit.COPAS, Rank.CINCO), c(Suit.COPAS, Rank.CUATRO)),
+                "p3" to listOf(c(Suit.OROS, Rank.SOTA), c(Suit.OROS, Rank.CABALLO), c(Suit.OROS, Rank.CUATRO), c(Suit.OROS, Rank.DOS)),
+                "p4" to listOf(c(Suit.BASTOS, Rank.REY), c(Suit.BASTOS, Rank.CABALLO), c(Suit.BASTOS, Rank.SOTA), c(Suit.BASTOS, Rank.CUATRO))
+            ),
+            manoId = "p1"
+        )
+    )
 }
 
 @Composable

--- a/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
+++ b/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -105,7 +106,7 @@ object DebugFeatures {
                 .statusBarsPadding()
         ) {
             ScenarioPanel(
-                onPick = { viewModel.startScenario(it) },
+                onPlay = { viewModel.startScenario(it) },
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .padding(8.dp)
@@ -115,8 +116,36 @@ object DebugFeatures {
 }
 
 @Composable
-private fun ScenarioPanel(onPick: (DebugScenario) -> Unit, modifier: Modifier = Modifier) {
+private fun ScenarioPanel(onPlay: (DebugScenario) -> Unit, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
     var expanded by remember { mutableStateOf(false) }
+    var saved by remember { mutableStateOf(ScenarioStore.load(context)) }
+
+    // null = editor cerrado; un DebugScenario "vacío sentinela" no sirve, así
+    // que usamos dos flags: editing!=null edita ese, isNew abre uno en blanco.
+    var editing by remember { mutableStateOf<DebugScenario?>(null) }
+    var isNew by remember { mutableStateOf(false) }
+
+    if (isNew || editing != null) {
+        ScenarioEditor(
+            initial = editing,
+            onSave = {
+                saved = ScenarioStore.upsert(context, it)
+                editing = null
+                isNew = false
+            },
+            onPlay = {
+                editing = null
+                isNew = false
+                expanded = false
+                onPlay(it)
+            },
+            onCancel = {
+                editing = null
+                isNew = false
+            }
+        )
+    }
 
     Column(
         modifier = modifier.padding(4.dp),
@@ -139,33 +168,109 @@ private fun ScenarioPanel(onPick: (DebugScenario) -> Unit, modifier: Modifier = 
         if (expanded) {
             LazyColumn(
                 modifier = Modifier
-                    .width(260.dp)
-                    .heightIn(max = 360.dp)
+                    .width(280.dp)
+                    .heightIn(max = 380.dp)
                     .padding(vertical = 4.dp)
                     .background(Color.Black.copy(alpha = 0.88f), RoundedCornerShape(8.dp))
                     .padding(8.dp),
                 verticalArrangement = Arrangement.spacedBy(6.dp)
             ) {
-                items(DebugScenarios.all) { scenario ->
+                item {
                     Box(
                         modifier = Modifier
-                            .background(Color(0xFF5D4037).copy(alpha = 0.9f), RoundedCornerShape(6.dp))
-                            .clickable {
-                                expanded = false
-                                onPick(scenario)
-                            }
-                            .padding(horizontal = 10.dp, vertical = 6.dp)
+                            .fillMaxWidth()
+                            .background(Color(0xFF1565C0), RoundedCornerShape(6.dp))
+                            .clickable { isNew = true }
+                            .padding(vertical = 8.dp),
+                        contentAlignment = Alignment.Center
                     ) {
-                        Text(
-                            text = scenario.name,
-                            color = Color.White,
-                            fontSize = 11.sp,
-                            lineHeight = 14.sp
+                        Text("＋ Nuevo escenario", color = Color.White, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                    }
+                }
+
+                if (saved.isNotEmpty()) {
+                    item { SectionLabel("Guardados") }
+                    items(saved, key = { it.name }) { scenario ->
+                        ScenarioRow(
+                            name = scenario.name,
+                            editable = true,
+                            onPlay = { expanded = false; onPlay(scenario) },
+                            onEdit = { editing = scenario },
+                            onDelete = { saved = ScenarioStore.delete(context, scenario.name) }
+                        )
+                    }
+                }
+
+                if (DebugScenarios.all.isNotEmpty()) {
+                    item { SectionLabel("Predefinidos") }
+                    items(DebugScenarios.all, key = { "pre-" + it.name }) { scenario ->
+                        ScenarioRow(
+                            name = scenario.name,
+                            editable = false,
+                            onPlay = { expanded = false; onPlay(scenario) },
+                            onEdit = {},
+                            onDelete = {}
                         )
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text = text.uppercase(),
+        color = Color(0xFF7A8794),
+        fontSize = 9.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(top = 4.dp, start = 2.dp)
+    )
+}
+
+@Composable
+private fun ScenarioRow(
+    name: String,
+    editable: Boolean,
+    onPlay: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFF2A3640).copy(alpha = 0.9f), RoundedCornerShape(6.dp))
+            .padding(horizontal = 8.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Text(
+            text = name,
+            color = Color.White,
+            fontSize = 11.sp,
+            lineHeight = 14.sp,
+            modifier = Modifier
+                .weight(1f)
+                .clickable { onPlay() }
+        )
+        RowAction("▶", Color(0xFF66BB6A), onPlay)
+        if (editable) {
+            RowAction("✎", Color(0xFFFFD24A), onEdit)
+            RowAction("🗑", Color(0xFFEF9A9A), onDelete)
+        }
+    }
+}
+
+@Composable
+private fun RowAction(glyph: String, color: Color, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .background(Color(0xFF1B232C), RoundedCornerShape(4.dp))
+            .clickable { onClick() }
+            .padding(horizontal = 7.dp, vertical = 4.dp)
+    ) {
+        Text(glyph, color = color, fontSize = 12.sp)
     }
 }
 

--- a/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
+++ b/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -101,12 +102,12 @@ object DebugFeatures {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .navigationBarsPadding()
+                .statusBarsPadding()
         ) {
             ScenarioPanel(
                 onPick = { viewModel.startScenario(it) },
                 modifier = Modifier
-                    .align(Alignment.BottomStart)
+                    .align(Alignment.TopCenter)
                     .padding(8.dp)
             )
         }
@@ -119,7 +120,7 @@ private fun ScenarioPanel(onPick: (DebugScenario) -> Unit, modifier: Modifier = 
 
     Column(
         modifier = modifier.padding(4.dp),
-        horizontalAlignment = Alignment.Start
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Box(
             modifier = Modifier

--- a/app/src/debug/java/com/doselfurioso/musvisto/debug/ScenarioEditor.kt
+++ b/app/src/debug/java/com/doselfurioso/musvisto/debug/ScenarioEditor.kt
@@ -1,0 +1,402 @@
+package com.doselfurioso.musvisto.debug
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.doselfurioso.musvisto.model.Card
+import com.doselfurioso.musvisto.model.DebugScenario
+import com.doselfurioso.musvisto.model.Rank
+import com.doselfurioso.musvisto.model.Suit
+
+/** Orden y etiquetas de jugadores tal como los crea GameViewModel.defaultPlayers(). */
+private val PLAYER_SLOTS = listOf(
+    "p1" to "Tú",
+    "p3" to "Pareja",
+    "p2" to "Rival Der.",
+    "p4" to "Rival Izq."
+)
+
+private fun suitColor(suit: Suit): Color = when (suit) {
+    Suit.OROS -> Color(0xFFFFC107)
+    Suit.COPAS -> Color(0xFFE53935)
+    Suit.ESPADAS -> Color(0xFF42A5F5)
+    Suit.BASTOS -> Color(0xFF66BB6A)
+}
+
+private fun rankLabel(rank: Rank): String = when (rank) {
+    Rank.AS -> "A"; Rank.DOS -> "2"; Rank.TRES -> "3"; Rank.CUATRO -> "4"
+    Rank.CINCO -> "5"; Rank.SEIS -> "6"; Rank.SIETE -> "7"; Rank.SOTA -> "S"
+    Rank.CABALLO -> "C"; Rank.REY -> "R"
+}
+
+/**
+ * Editor de escenarios in-app (solo build debug).
+ *
+ * Permite construir las 4 manos carta a carta sin recompilar: evita cartas
+ * repetidas, elige mano y `startAtMus`, y guarda/juega el escenario. `initial`
+ * != null edita uno existente (la edición se identifica por nombre).
+ */
+@Composable
+fun ScenarioEditor(
+    initial: DebugScenario?,
+    onSave: (DebugScenario) -> Unit,
+    onPlay: (DebugScenario) -> Unit,
+    onCancel: () -> Unit
+) {
+    var name by remember { mutableStateOf(initial?.name ?: "") }
+    var manoId by remember { mutableStateOf(initial?.manoId ?: "p1") }
+    var startAtMus by remember { mutableStateOf(initial?.startAtMus ?: false) }
+
+    // hands: por jugador, 4 huecos nullable. Se reemplaza el mapa entero en
+    // cada edición para que Compose recomponga (sin estado mutable anidado).
+    var hands by remember {
+        mutableStateOf(
+            PLAYER_SLOTS.associate { (id, _) ->
+                val h = initial?.hands?.get(id) ?: emptyList()
+                id to List(4) { i -> h.getOrNull(i) }
+            }
+        )
+    }
+    var activeSlot by remember { mutableStateOf<Pair<String, Int>?>("p1" to 0) }
+
+    val usedCards = hands.values.flatten().filterNotNull().toSet()
+
+    fun firstEmptySlot(): Pair<String, Int>? {
+        for ((id, _) in PLAYER_SLOTS) {
+            val idx = hands[id]!!.indexOfFirst { it == null }
+            if (idx >= 0) return id to idx
+        }
+        return null
+    }
+
+    fun setSlot(target: Pair<String, Int>, card: Card?) {
+        hands = hands.toMutableMap().apply {
+            this[target.first] = this[target.first]!!.toMutableList().apply {
+                this[target.second] = card
+            }
+        }
+    }
+
+    fun onCardTap(card: Card) {
+        // Carta ya usada: si es la del hueco activo, la quita; si no, ignora.
+        if (card in usedCards) {
+            val slot = activeSlot ?: return
+            if (hands[slot.first]!![slot.second] == card) setSlot(slot, null)
+            return
+        }
+        val slot = activeSlot ?: firstEmptySlot() ?: return
+        setSlot(slot, card)
+        activeSlot = firstEmptySlot()
+    }
+
+    val complete = hands.values.all { row -> row.all { it != null } }
+    val canSave = name.isNotBlank() && complete
+
+    fun build(): DebugScenario = DebugScenario(
+        name = name.trim(),
+        hands = hands.mapValues { (_, row) -> row.filterNotNull() },
+        manoId = manoId,
+        startAtMus = startAtMus
+    )
+
+    Dialog(
+        onDismissRequest = onCancel,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color(0xFF101418))
+                .padding(12.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Text(
+                    text = if (initial == null) "Nuevo escenario" else "Editar escenario",
+                    color = Color(0xFFFFD24A),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold
+                )
+
+                // --- Nombre ---
+                Text("Nombre", color = Color.Gray, fontSize = 11.sp)
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFF1E2630), RoundedCornerShape(6.dp))
+                        .padding(horizontal = 10.dp, vertical = 8.dp)
+                ) {
+                    BasicTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        singleLine = true,
+                        textStyle = TextStyle(color = Color.White, fontSize = 13.sp),
+                        cursorBrush = androidx.compose.ui.graphics.SolidColor(Color(0xFFFFD24A)),
+                        modifier = Modifier.fillMaxWidth(),
+                        decorationBox = { inner ->
+                            if (name.isEmpty()) {
+                                Text("p. ej. Duples reyes vs cincos", color = Color(0xFF5A6470), fontSize = 13.sp)
+                            }
+                            inner()
+                        }
+                    )
+                }
+
+                // --- Mano + arranque ---
+                Text("Mano (reparte y abre)", color = Color.Gray, fontSize = 11.sp)
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    PLAYER_SLOTS.forEach { (id, label) ->
+                        Chip(
+                            text = label,
+                            selected = manoId == id,
+                            onClick = { manoId = id },
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .clickable { startAtMus = !startAtMus }
+                        .padding(vertical = 2.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(18.dp)
+                            .background(
+                                if (startAtMus) Color(0xFF43A047) else Color(0xFF424242),
+                                RoundedCornerShape(4.dp)
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (startAtMus) Text("✓", color = Color.White, fontSize = 12.sp)
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        "Arrancar en MUS (probar corte/descarte). Si no, aterriza en GRANDE.",
+                        color = Color.LightGray,
+                        fontSize = 11.sp
+                    )
+                }
+
+                // --- Manos ---
+                PLAYER_SLOTS.forEach { (id, label) ->
+                    val row = hands[id]!!
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(Color(0xFF18202A), RoundedCornerShape(8.dp))
+                            .padding(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                "$label ($id)",
+                                color = Color.White,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Text(
+                                "Vaciar",
+                                color = Color(0xFFEF9A9A),
+                                fontSize = 11.sp,
+                                modifier = Modifier
+                                    .clickable {
+                                        hands = hands.toMutableMap()
+                                            .apply { this[id] = List(4) { null } }
+                                        activeSlot = id to 0
+                                    }
+                                    .padding(horizontal = 6.dp, vertical = 2.dp)
+                            )
+                        }
+                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                            row.forEachIndexed { idx, card ->
+                                val isActive = activeSlot == (id to idx)
+                                Box(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .height(38.dp)
+                                        .background(
+                                            Color(0xFF0E1318),
+                                            RoundedCornerShape(6.dp)
+                                        )
+                                        .border(
+                                            width = if (isActive) 2.dp else 1.dp,
+                                            color = if (isActive) Color(0xFFFFD24A) else Color(0xFF33404D),
+                                            shape = RoundedCornerShape(6.dp)
+                                        )
+                                        .clickable { activeSlot = id to idx },
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    if (card != null) {
+                                        Text(
+                                            rankLabel(card.rank),
+                                            color = suitColor(card.suit),
+                                            fontSize = 16.sp,
+                                            fontWeight = FontWeight.Bold
+                                        )
+                                    } else {
+                                        Text("·", color = Color(0xFF44505C), fontSize = 16.sp)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // --- Baraja ---
+                Text(
+                    "Baraja — toca para asignar al hueco activo",
+                    color = Color.Gray,
+                    fontSize = 11.sp
+                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFF18202A), RoundedCornerShape(8.dp))
+                        .padding(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Suit.values().forEach { suit ->
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(3.dp),
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Rank.values().forEach { rank ->
+                                val card = Card(suit, rank)
+                                val used = card in usedCards
+                                Box(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .height(30.dp)
+                                        .background(
+                                            if (used) Color(0xFF0C0F12) else Color(0xFF222C36),
+                                            RoundedCornerShape(4.dp)
+                                        )
+                                        .clickable { onCardTap(card) },
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        rankLabel(rank),
+                                        color = if (used) Color(0xFF3A4450) else suitColor(suit),
+                                        fontSize = 13.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        textAlign = TextAlign.Center
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (!canSave) {
+                    Text(
+                        text = when {
+                            name.isBlank() -> "Falta el nombre."
+                            !complete -> "Cada jugador necesita 4 cartas."
+                            else -> ""
+                        },
+                        color = Color(0xFFEF9A9A),
+                        fontSize = 11.sp
+                    )
+                }
+
+                // --- Acciones ---
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(top = 4.dp, bottom = 24.dp)
+                ) {
+                    ActionButton("Cancelar", Color(0xFF424242), Modifier.weight(1f)) { onCancel() }
+                    ActionButton(
+                        "Guardar",
+                        if (canSave) Color(0xFF1565C0) else Color(0xFF2A3640),
+                        Modifier.weight(1f),
+                        enabled = canSave
+                    ) { onSave(build()) }
+                    ActionButton(
+                        "Jugar",
+                        if (complete) Color(0xFF43A047) else Color(0xFF2A3640),
+                        Modifier.weight(1f),
+                        enabled = complete
+                    ) { onPlay(build()) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Chip(text: String, selected: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .background(
+                if (selected) Color(0xFFFFD24A) else Color(0xFF2A3640),
+                RoundedCornerShape(6.dp)
+            )
+            .clickable { onClick() }
+            .padding(vertical = 8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text,
+            color = if (selected) Color(0xFF101418) else Color.White,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+private fun ActionButton(
+    text: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .background(color, RoundedCornerShape(6.dp))
+            .clickable(enabled = enabled) { onClick() }
+            .padding(vertical = 12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text, color = Color.White, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+    }
+}

--- a/app/src/debug/java/com/doselfurioso/musvisto/debug/ScenarioStore.kt
+++ b/app/src/debug/java/com/doselfurioso/musvisto/debug/ScenarioStore.kt
@@ -1,0 +1,56 @@
+package com.doselfurioso.musvisto.debug
+
+import android.content.Context
+import android.util.Log
+import com.doselfurioso.musvisto.model.DebugScenario
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Persistencia de escenarios creados en la app (solo build debug).
+ *
+ * Mismo patrón que `GameRepository`: JSON en SharedPreferences propios. No
+ * existe en release (este archivo solo se compila en `src/debug/`), así que
+ * nada de esto llega a producción.
+ */
+object ScenarioStore {
+    private const val PREFS_NAME = "MusVistoDebugScenarios"
+    private const val KEY_LIST = "scenarios"
+
+    fun load(context: Context): List<DebugScenario> {
+        return try {
+            val json = context
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getString(KEY_LIST, null) ?: return emptyList()
+            Json.decodeFromString<List<DebugScenario>>(json)
+        } catch (e: Exception) {
+            Log.e("ScenarioStore", "Error cargando escenarios", e)
+            emptyList()
+        }
+    }
+
+    fun save(context: Context, scenarios: List<DebugScenario>) {
+        try {
+            val json = Json.encodeToString(scenarios)
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit().putString(KEY_LIST, json).apply()
+        } catch (e: Exception) {
+            Log.e("ScenarioStore", "Error guardando escenarios", e)
+        }
+    }
+
+    /** Inserta o reemplaza por nombre (el nombre es la clave de edición). */
+    fun upsert(context: Context, scenario: DebugScenario): List<DebugScenario> {
+        val current = load(context).toMutableList()
+        val idx = current.indexOfFirst { it.name == scenario.name }
+        if (idx >= 0) current[idx] = scenario else current.add(scenario)
+        save(context, current)
+        return current
+    }
+
+    fun delete(context: Context, name: String): List<DebugScenario> {
+        val current = load(context).filterNot { it.name == name }
+        save(context, current)
+        return current
+    }
+}

--- a/app/src/main/java/com/doselfurioso/musvisto/model/DebugScenario.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/model/DebugScenario.kt
@@ -1,0 +1,24 @@
+package com.doselfurioso.musvisto.model
+
+/**
+ * Escenario de prueba para forzar una situación concreta de partida desde el
+ * panel de debug (manos exactas, quién es mano, en qué lance arrancar).
+ *
+ * Es un modelo puro; las instancias concretas viven en `src/debug/` y solo se
+ * usan en builds debug. En release el selector es un no-op y nadie las crea.
+ *
+ * @param name etiqueta visible en el panel de debug.
+ * @param hands mano forzada por id de jugador ("p1" humano, "p2"/"p3"/"p4" IA).
+ *              Cada lista debe tener 4 cartas y no repetir cartas entre manos.
+ * @param manoId jugador que es "mano" en la ronda.
+ * @param startAtMus si es `true`, la partida arranca en MUS (para probar
+ *              corte de Mus / descarte). Si es `false` (por defecto), se emite
+ *              un "No hay mus" del mano y la partida aterriza en GRANDE con las
+ *              manos exactas intactas (sin descarte que las altere).
+ */
+data class DebugScenario(
+    val name: String,
+    val hands: Map<String, List<Card>>,
+    val manoId: String,
+    val startAtMus: Boolean = false
+)

--- a/app/src/main/java/com/doselfurioso/musvisto/model/DebugScenario.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/model/DebugScenario.kt
@@ -1,5 +1,7 @@
 package com.doselfurioso.musvisto.model
 
+import kotlinx.serialization.Serializable
+
 /**
  * Escenario de prueba para forzar una situación concreta de partida desde el
  * panel de debug (manos exactas, quién es mano, en qué lance arrancar).
@@ -16,6 +18,7 @@ package com.doselfurioso.musvisto.model
  *              un "No hay mus" del mano y la partida aterriza en GRANDE con las
  *              manos exactas intactas (sin descarte que las altere).
  */
+@Serializable
 data class DebugScenario(
     val name: String,
     val hands: Map<String, List<Card>>,

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -388,6 +388,9 @@ fun GameScreen(
             // Panel flotante de logs de IA — solo se renderiza en builds debug.
             DebugFeatures.AiDebugPanelOverlay(gameViewModel)
 
+            // Selector de escenarios de prueba — solo se renderiza en builds debug.
+            DebugFeatures.ScenarioSelectorOverlay(gameViewModel)
+
             if (gameState.isSelectingBet) {
                 Box(
                     modifier = Modifier

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
@@ -23,8 +23,6 @@ class GameViewModel constructor(
     private val gameRepository: GameRepository
 ) : ViewModel() {
 
-    private val manualDealingEnabled = true
-
     private val TAG = "GameViewModelDebug"
 
     private val _gameState = MutableStateFlow(GameState())
@@ -62,42 +60,50 @@ class GameViewModel constructor(
         }
     }
 
-    private fun dealManualHands(players: List<Player>, deck: List<Card>): Pair<List<Player>, List<Card>> {
-        // Define aquí las manos que quieres probar
-        val manualHands = mapOf(
-            "p1" to listOf( // Mano del Jugador Humano
-                Card(Suit.OROS, Rank.REY),
-                Card(Suit.OROS, Rank.CABALLO),
-                Card(Suit.OROS, Rank.CABALLO),
-                Card(Suit.OROS, Rank.AS)
-            ),
-            "p2" to listOf( // Mano del Rival Izquierdo
-                Card(Suit.COPAS, Rank.REY),
-                Card(Suit.COPAS, Rank.REY),
-                Card(Suit.COPAS, Rank.CINCO),
-                Card(Suit.COPAS, Rank.CINCO)
-            ),
-            "p3" to listOf( // Mano del Compañero
-                Card(Suit.OROS, Rank.REY),
-                Card(Suit.OROS, Rank.CABALLO),
-                Card(Suit.OROS, Rank.SOTA),
-                Card(Suit.OROS, Rank.CUATRO)
-            ),
-            "p4" to listOf( // Mano del Rival Derecho
-                Card(Suit.BASTOS, Rank.REY),
-                Card(Suit.BASTOS, Rank.CABALLO),
-                Card(Suit.BASTOS, Rank.CUATRO),
-                Card(Suit.BASTOS, Rank.AS)
-            )
+    private fun defaultPlayers(): List<Player> = listOf(
+        Player(id = "p1", name = "Tú", avatarResId = R.drawable.avatar_castilla, isAi = false, team = "teamA"),
+        Player(id = "p4", name = "Rival Izq.", avatarResId = R.drawable.avatar_navarra, isAi = true, team = "teamB"),
+        Player(id = "p3", name = "Pareja", avatarResId = R.drawable.avatar_aragon, isAi = true, team = "teamA"),
+        Player(id = "p2", name = "Rival Der.", avatarResId = R.drawable.avatar_granada, isAi = true, team = "teamB")
+    )
+
+    /**
+     * Arranca una partida de prueba con manos forzadas (panel de debug).
+     *
+     * Reparte las manos exactas del escenario y, salvo que pida arrancar en
+     * MUS, emite un "No hay mus" del mano para aterrizar en GRANDE con las 16
+     * cartas intactas (un solo NoMus cierra el Mus por reglas; no hay descarte
+     * que altere las manos). A partir de ahí el motor es el normal.
+     */
+    fun startScenario(scenario: DebugScenario) {
+        val score = mapOf("teamA" to 0, "teamB" to 0)
+        val players = defaultPlayers().map {
+            it.copy(hand = scenario.hands[it.id] ?: emptyList())
+        }
+        val dealtCards = scenario.hands.values.flatten().toSet()
+        val remainingDeck = gameLogic.createDeck().filter { it !in dealtCards }
+
+        val musState = GameState(
+            players = players,
+            deck = remainingDeck,
+            score = score,
+            manoPlayerId = scenario.manoId,
+            currentTurnPlayerId = scenario.manoId,
+            gamePhase = GamePhase.MUS,
+            availableActions = listOf(GameAction.Mus, GameAction.NoMus)
         )
 
-        val updatedPlayers = players.map { it.copy(hand = manualHands[it.id] ?: emptyList()) }
-
-        // Eliminamos las cartas repartidas del mazo para que no haya duplicados
-        val dealtCards = manualHands.values.flatten().toSet()
-        val remainingDeck = deck.filter { it !in dealtCards }
-
-        return Pair(updatedPlayers, remainingDeck)
+        if (scenario.startAtMus) {
+            _gameState.value = musState
+        } else {
+            // Un único "No hay mus" del mano cierra el Mus → GRANDE, sin tocar
+            // las manos (handleNoMus no reparte).
+            _gameState.value = gameLogic.processAction(
+                musState, GameAction.NoMus, scenario.manoId
+            )
+        }
+        handleAiTurn()
+        triggerAiGestures()
     }
 
 
@@ -433,14 +439,7 @@ class GameViewModel constructor(
     private fun startNewGame(initialScore: Map<String, Int>?, lastManoPlayerId: String?) {
         val score = initialScore ?: mapOf("teamA" to 0, "teamB" to 0)
 
-        val players = _gameState.value.players.ifEmpty {
-            listOf(
-                Player(id = "p1", name = "Tú", avatarResId = R.drawable.avatar_castilla, isAi = false, team = "teamA"),
-                Player(id = "p4", name = "Rival Izq.", avatarResId = R.drawable.avatar_navarra, isAi = true, team = "teamB"),
-                Player(id = "p3", name = "Pareja", avatarResId = R.drawable.avatar_aragon, isAi = true, team = "teamA"),
-                Player(id = "p2", name = "Rival Der.", avatarResId = R.drawable.avatar_granada, isAi = true, team = "teamB")
-            )
-        }
+        val players = _gameState.value.players.ifEmpty { defaultPlayers() }
 
         val newManoId = if (lastManoPlayerId != null) {
             val lastManoIndex = players.indexOfFirst { it.id == lastManoPlayerId }

--- a/app/src/release/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
+++ b/app/src/release/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
@@ -23,4 +23,9 @@ object DebugFeatures {
     fun DebugToggleButton(viewModel: GameViewModel) {
         // No-op en release.
     }
+
+    @Composable
+    fun ScenarioSelectorOverlay(viewModel: GameViewModel) {
+        // No-op en release.
+    }
 }


### PR DESCRIPTION
@
Permite forzar situaciones concretas de partida (manos, mano, lance) para
validar la IA en casos que el simulador no juzga y no se pueden forzar
jugando. Todo en `src/debug/` + un hook en `GameViewModel`; release = no-op.

## Qué incluye
- **Harness** (`startScenario`): reparte 4 manos exactas + mano; salvo
  `startAtMus`, emite un `NoMus` del mano → aterriza en GRANDE con las 16
  cartas intactas (un solo NoMus cierra Mus por reglas; sin descarte que las
  altere; cero riesgo de invariantes). `DebugScenario` en `model/`,
  `@Serializable`. Limpia código muerto `manualDealingEnabled`/
  `dealManualHands` (KNOWN_ISSUES L17); `defaultPlayers()` deduplica.
- **Editor in-app**: rejilla de 40 cartas (evita repetidas, auto-avance de
  hueco), selector de mano, toggle `startAtMus`, guardar/editar/borrar/jugar.
  Persistencia en SharedPreferences propios (`ScenarioStore`).
- Panel de debug abajo-centro: lista Guardados + Predefinidos.

## Verificación
- Debug + release compilan; `testDebugUnitTest` verde (39).
- UI: verificación visual del usuario en playtest (debug-only, no afecta release).
@