### PR TITLE
test(ai): red de seguridad — snapshot de paridad determinista de IA

### DIFF
--- a/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicSnapshotTest.kt
+++ b/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicSnapshotTest.kt
@@ -1,0 +1,307 @@
+package com.doselfurioso.musvisto.logic
+
+import com.doselfurioso.musvisto.model.*
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+import kotlin.random.Random
+
+/**
+ * Snapshot de PARIDAD DETERMINISTA de [AILogic.makeDecision].
+ *
+ * Matriz de regresión de IA que vive en master, independiente del
+ * simulador (que está en otra rama y mide calidad agregada, no paridad
+ * caso-a-caso). Para cada caso del corpus se crea una `AILogic` con `rng`
+ * de semilla FIJA y se serializa la decisión (acción + cartas a descartar;
+ * NO el debugLog, que incluye un UUID aleatorio). Cada caso usa su propia
+ * instancia con la misma semilla → independiente del orden y de añadir
+ * casos nuevos.
+ *
+ * Si esto se rompe tras un refactor de AILogic, las decisiones cambiaron:
+ * el refactor NO fue de comportamiento-cero. Para regenerar el golden a
+ * propósito (cambio de IA intencional), copiar el contenido del archivo
+ * `app/build/ai-snapshot-actual.txt` a [EXPECTED].
+ */
+class AILogicSnapshotTest {
+
+    private val gameLogic = MusGameLogic(Random(0))
+    private val SEED = 777L
+
+    private fun c(s: Suit, r: Rank) = Card(s, r)
+
+    // Arquetipos de mano.
+    private val fourKings = listOf(c(Suit.OROS, Rank.REY), c(Suit.COPAS, Rank.REY), c(Suit.ESPADAS, Rank.REY), c(Suit.BASTOS, Rank.REY))
+    private val juego31 = listOf(c(Suit.OROS, Rank.SOTA), c(Suit.COPAS, Rank.SOTA), c(Suit.ESPADAS, Rank.SOTA), c(Suit.BASTOS, Rank.AS))
+    private val duplesRC = listOf(c(Suit.OROS, Rank.REY), c(Suit.COPAS, Rank.REY), c(Suit.ESPADAS, Rank.CINCO), c(Suit.BASTOS, Rank.CINCO))
+    private val weak = listOf(c(Suit.OROS, Rank.REY), c(Suit.COPAS, Rank.SOTA), c(Suit.ESPADAS, Rank.CUATRO), c(Suit.BASTOS, Rank.AS))
+    private val lowChica = listOf(c(Suit.OROS, Rank.AS), c(Suit.COPAS, Rank.CUATRO), c(Suit.ESPADAS, Rank.CINCO), c(Suit.BASTOS, Rank.SEIS))
+    private val medium = listOf(c(Suit.OROS, Rank.REY), c(Suit.COPAS, Rank.CABALLO), c(Suit.ESPADAS, Rank.SIETE), c(Suit.BASTOS, Rank.CUATRO))
+
+    private val archetypes = listOf(
+        "4REY" to fourKings, "J31" to juego31, "DUP" to duplesRC,
+        "WEAK" to weak, "LOWC" to lowChica, "MED" to medium
+    )
+
+    /** ai = p2 (teamB). Compañero p4 (teamB). Rivales p1/p3 (teamA). */
+    private fun state(
+        aiHand: List<Card>,
+        phase: GamePhase,
+        manoId: String = "p2",
+        myScore: Int = 0,
+        oppScore: Int = 0,
+        bet: BetInfo? = null
+    ): Pair<GameState, Player> {
+        val p1 = Player("p1", "p1", team = "teamA", avatarResId = 0, hand = medium)
+        val p2 = Player("p2", "p2", team = "teamB", avatarResId = 0, isAi = true, hand = aiHand)
+        val p3 = Player("p3", "p3", team = "teamA", avatarResId = 0, hand = medium)
+        val p4 = Player("p4", "p4", team = "teamB", avatarResId = 0, isAi = true, hand = weak)
+        val gs = GameState(
+            players = listOf(p1, p2, p3, p4),
+            gamePhase = phase,
+            manoPlayerId = manoId,
+            currentTurnPlayerId = "p2",
+            currentBet = bet,
+            score = mapOf("teamA" to oppScore, "teamB" to myScore)
+        )
+        return gs to p2
+    }
+
+    private fun serialize(a: GameAction): String = when (a) {
+        is GameAction.Envido -> "Envido(${a.amount})"
+        is GameAction.ConfirmDiscard -> "ConfirmDiscard"
+        else -> a::class.simpleName ?: a.toString()
+    }
+
+    private fun decide(name: String, gs: GameState, ai: Player): String {
+        val ai1 = AILogic(gameLogic, Random(SEED))
+        val d = ai1.makeDecision(gs, ai)
+        val cards = d.cardsToDiscard
+            .map { it.suit.name.take(1) + it.rank.name.take(2) }
+            .sorted()
+            .joinToString(",")
+        return "$name => ${serialize(d.action)}" + if (cards.isNotEmpty()) " [$cards]" else ""
+    }
+
+    @Test
+    fun `ai decision snapshot - paridad determinista`() {
+        val lines = mutableListOf<String>()
+
+        // MUS y DISCARD por arquetipo, con mano propia y con mano del compañero.
+        for ((tag, hand) in archetypes) {
+            for (mano in listOf("p2", "p4")) {
+                val (gs, ai) = state(hand, GamePhase.MUS, manoId = mano)
+                lines += decide("MUS/$tag/mano=$mano", gs, ai)
+            }
+            val (gd, ad) = state(hand, GamePhase.DISCARD)
+            lines += decide("DISCARD/$tag", gd, ad)
+        }
+
+        // Apertura de lance por arquetipo y fase, con marcador par / detrás / delante.
+        for ((tag, hand) in archetypes) {
+            for (phase in listOf(GamePhase.GRANDE, GamePhase.CHICA, GamePhase.PARES, GamePhase.JUEGO)) {
+                for ((sTag, my, op) in listOf(
+                    Triple("par", 15, 15), Triple("detras", 5, 30), Triple("delante", 30, 5)
+                )) {
+                    val (gs, ai) = state(hand, phase, myScore = my, oppScore = op)
+                    lines += decide("OPEN/$phase/$tag/$sTag", gs, ai)
+                }
+            }
+        }
+
+        // Respuesta a envite normal y a órdago, mano vs postre, marcador variado.
+        for ((tag, hand) in archetypes) {
+            val normalBet = BetInfo(amount = 2, bettingPlayerId = "p1", respondingPlayerId = "p2")
+            val ordago = BetInfo(amount = 40, bettingPlayerId = "p1", respondingPlayerId = "p2", isOrdago = true)
+            for (phase in listOf(GamePhase.GRANDE, GamePhase.PARES, GamePhase.JUEGO)) {
+                run {
+                    val (gs, ai) = state(hand, phase, manoId = "p2", bet = normalBet)
+                    lines += decide("RESP/$phase/$tag/bet/mano", gs, ai)
+                }
+                run {
+                    val (gs, ai) = state(hand, phase, manoId = "p1", bet = normalBet)
+                    lines += decide("RESP/$phase/$tag/bet/postre", gs, ai)
+                }
+                run {
+                    val (gs, ai) = state(hand, phase, manoId = "p2", bet = ordago)
+                    lines += decide("RESP/$phase/$tag/ordago/even", gs, ai)
+                }
+                run {
+                    val (gs, ai) = state(hand, phase, manoId = "p2", myScore = 5, oppScore = 35, bet = ordago)
+                    lines += decide("RESP/$phase/$tag/ordago/hailmary", gs, ai)
+                }
+            }
+        }
+
+        val actual = lines.joinToString("\n")
+        File("build/ai-snapshot-actual.txt").apply { parentFile?.mkdirs() }.writeText(actual)
+        assertEquals(EXPECTED.trim(), actual.trim())
+    }
+
+    companion object {
+        // Capturado de master. Regenerar SOLO si la IA cambia a propósito.
+        private val EXPECTED = """
+MUS/4REY/mano=p2 => NoMus
+MUS/4REY/mano=p4 => NoMus
+DISCARD/4REY => ConfirmDiscard [ORE]
+MUS/J31/mano=p2 => NoMus
+MUS/J31/mano=p4 => NoMus
+DISCARD/J31 => ConfirmDiscard [OSO]
+MUS/DUP/mano=p2 => NoMus
+MUS/DUP/mano=p4 => NoMus
+DISCARD/DUP => ConfirmDiscard [ECI]
+MUS/WEAK/mano=p2 => Mus
+MUS/WEAK/mano=p4 => Mus
+DISCARD/WEAK => ConfirmDiscard [BAS,CSO,ECU]
+MUS/LOWC/mano=p2 => Mus
+MUS/LOWC/mano=p4 => Mus
+DISCARD/LOWC => ConfirmDiscard [BSE,CCU,ECI,OAS]
+MUS/MED/mano=p2 => NoMus
+MUS/MED/mano=p4 => NoMus
+DISCARD/MED => ConfirmDiscard [BCU]
+OPEN/GRANDE/4REY/par => Envido(5)
+OPEN/GRANDE/4REY/detras => Órdago
+OPEN/GRANDE/4REY/delante => Envido(4)
+OPEN/CHICA/4REY/par => Paso
+OPEN/CHICA/4REY/detras => Paso
+OPEN/CHICA/4REY/delante => Paso
+OPEN/PARES/4REY/par => Envido(5)
+OPEN/PARES/4REY/detras => Órdago
+OPEN/PARES/4REY/delante => Envido(4)
+OPEN/JUEGO/4REY/par => Paso
+OPEN/JUEGO/4REY/detras => Envido(3)
+OPEN/JUEGO/4REY/delante => Paso
+OPEN/GRANDE/J31/par => Paso
+OPEN/GRANDE/J31/detras => Paso
+OPEN/GRANDE/J31/delante => Paso
+OPEN/CHICA/J31/par => Paso
+OPEN/CHICA/J31/detras => Envido(3)
+OPEN/CHICA/J31/delante => Paso
+OPEN/PARES/J31/par => Envido(4)
+OPEN/PARES/J31/detras => Órdago
+OPEN/PARES/J31/delante => Envido(3)
+OPEN/JUEGO/J31/par => Envido(5)
+OPEN/JUEGO/J31/detras => Órdago
+OPEN/JUEGO/J31/delante => Envido(4)
+OPEN/GRANDE/DUP/par => Envido(3)
+OPEN/GRANDE/DUP/detras => Órdago
+OPEN/GRANDE/DUP/delante => Paso
+OPEN/CHICA/DUP/par => Paso
+OPEN/CHICA/DUP/detras => Paso
+OPEN/CHICA/DUP/delante => Paso
+OPEN/PARES/DUP/par => Envido(5)
+OPEN/PARES/DUP/detras => Órdago
+OPEN/PARES/DUP/delante => Envido(4)
+OPEN/JUEGO/DUP/par => Paso
+OPEN/JUEGO/DUP/detras => Paso
+OPEN/JUEGO/DUP/delante => Paso
+OPEN/GRANDE/WEAK/par => Paso
+OPEN/GRANDE/WEAK/detras => Envido(3)
+OPEN/GRANDE/WEAK/delante => Paso
+OPEN/CHICA/WEAK/par => Paso
+OPEN/CHICA/WEAK/detras => Envido(3)
+OPEN/CHICA/WEAK/delante => Paso
+OPEN/PARES/WEAK/par => Paso
+OPEN/PARES/WEAK/detras => Paso
+OPEN/PARES/WEAK/delante => Paso
+OPEN/JUEGO/WEAK/par => Paso
+OPEN/JUEGO/WEAK/detras => Paso
+OPEN/JUEGO/WEAK/delante => Paso
+OPEN/GRANDE/LOWC/par => Paso
+OPEN/GRANDE/LOWC/detras => Paso
+OPEN/GRANDE/LOWC/delante => Paso
+OPEN/CHICA/LOWC/par => Paso
+OPEN/CHICA/LOWC/detras => Envido(3)
+OPEN/CHICA/LOWC/delante => Paso
+OPEN/PARES/LOWC/par => Paso
+OPEN/PARES/LOWC/detras => Paso
+OPEN/PARES/LOWC/delante => Paso
+OPEN/JUEGO/LOWC/par => Paso
+OPEN/JUEGO/LOWC/detras => Paso
+OPEN/JUEGO/LOWC/delante => Paso
+OPEN/GRANDE/MED/par => Paso
+OPEN/GRANDE/MED/detras => Envido(3)
+OPEN/GRANDE/MED/delante => Paso
+OPEN/CHICA/MED/par => Paso
+OPEN/CHICA/MED/detras => Paso
+OPEN/CHICA/MED/delante => Paso
+OPEN/PARES/MED/par => Paso
+OPEN/PARES/MED/detras => Paso
+OPEN/PARES/MED/delante => Paso
+OPEN/JUEGO/MED/par => Envido(5)
+OPEN/JUEGO/MED/detras => Órdago
+OPEN/JUEGO/MED/delante => Envido(4)
+RESP/GRANDE/4REY/bet/mano => Envido(5)
+RESP/GRANDE/4REY/bet/postre => Envido(5)
+RESP/GRANDE/4REY/ordago/even => Quiero
+RESP/GRANDE/4REY/ordago/hailmary => Quiero
+RESP/PARES/4REY/bet/mano => Envido(5)
+RESP/PARES/4REY/bet/postre => Envido(5)
+RESP/PARES/4REY/ordago/even => Quiero
+RESP/PARES/4REY/ordago/hailmary => Quiero
+RESP/JUEGO/4REY/bet/mano => NoQuiero
+RESP/JUEGO/4REY/bet/postre => NoQuiero
+RESP/JUEGO/4REY/ordago/even => NoQuiero
+RESP/JUEGO/4REY/ordago/hailmary => Quiero
+RESP/GRANDE/J31/bet/mano => NoQuiero
+RESP/GRANDE/J31/bet/postre => NoQuiero
+RESP/GRANDE/J31/ordago/even => NoQuiero
+RESP/GRANDE/J31/ordago/hailmary => Quiero
+RESP/PARES/J31/bet/mano => Quiero
+RESP/PARES/J31/bet/postre => Quiero
+RESP/PARES/J31/ordago/even => Quiero
+RESP/PARES/J31/ordago/hailmary => Quiero
+RESP/JUEGO/J31/bet/mano => Envido(5)
+RESP/JUEGO/J31/bet/postre => Quiero
+RESP/JUEGO/J31/ordago/even => Quiero
+RESP/JUEGO/J31/ordago/hailmary => Quiero
+RESP/GRANDE/DUP/bet/mano => NoQuiero
+RESP/GRANDE/DUP/bet/postre => NoQuiero
+RESP/GRANDE/DUP/ordago/even => NoQuiero
+RESP/GRANDE/DUP/ordago/hailmary => Quiero
+RESP/PARES/DUP/bet/mano => Envido(5)
+RESP/PARES/DUP/bet/postre => Envido(5)
+RESP/PARES/DUP/ordago/even => Quiero
+RESP/PARES/DUP/ordago/hailmary => Quiero
+RESP/JUEGO/DUP/bet/mano => NoQuiero
+RESP/JUEGO/DUP/bet/postre => NoQuiero
+RESP/JUEGO/DUP/ordago/even => NoQuiero
+RESP/JUEGO/DUP/ordago/hailmary => Quiero
+RESP/GRANDE/WEAK/bet/mano => NoQuiero
+RESP/GRANDE/WEAK/bet/postre => NoQuiero
+RESP/GRANDE/WEAK/ordago/even => NoQuiero
+RESP/GRANDE/WEAK/ordago/hailmary => Quiero
+RESP/PARES/WEAK/bet/mano => NoQuiero
+RESP/PARES/WEAK/bet/postre => NoQuiero
+RESP/PARES/WEAK/ordago/even => NoQuiero
+RESP/PARES/WEAK/ordago/hailmary => Quiero
+RESP/JUEGO/WEAK/bet/mano => NoQuiero
+RESP/JUEGO/WEAK/bet/postre => NoQuiero
+RESP/JUEGO/WEAK/ordago/even => NoQuiero
+RESP/JUEGO/WEAK/ordago/hailmary => Quiero
+RESP/GRANDE/LOWC/bet/mano => NoQuiero
+RESP/GRANDE/LOWC/bet/postre => NoQuiero
+RESP/GRANDE/LOWC/ordago/even => NoQuiero
+RESP/GRANDE/LOWC/ordago/hailmary => Quiero
+RESP/PARES/LOWC/bet/mano => NoQuiero
+RESP/PARES/LOWC/bet/postre => NoQuiero
+RESP/PARES/LOWC/ordago/even => NoQuiero
+RESP/PARES/LOWC/ordago/hailmary => Quiero
+RESP/JUEGO/LOWC/bet/mano => NoQuiero
+RESP/JUEGO/LOWC/bet/postre => NoQuiero
+RESP/JUEGO/LOWC/ordago/even => NoQuiero
+RESP/JUEGO/LOWC/ordago/hailmary => Quiero
+RESP/GRANDE/MED/bet/mano => NoQuiero
+RESP/GRANDE/MED/bet/postre => NoQuiero
+RESP/GRANDE/MED/ordago/even => NoQuiero
+RESP/GRANDE/MED/ordago/hailmary => Quiero
+RESP/PARES/MED/bet/mano => NoQuiero
+RESP/PARES/MED/bet/postre => NoQuiero
+RESP/PARES/MED/ordago/even => NoQuiero
+RESP/PARES/MED/ordago/hailmary => Quiero
+RESP/JUEGO/MED/bet/mano => Envido(5)
+RESP/JUEGO/MED/bet/postre => Quiero
+RESP/JUEGO/MED/ordago/even => Quiero
+RESP/JUEGO/MED/ordago/hailmary => Quiero
+""".trimIndent()
+    }
+}


### PR DESCRIPTION
@
**Tier 0 / PR 0b** del refactor clean-code. Solo tests, cero código de
producción → riesgo nulo.

Añade `AILogicSnapshotTest`: matriz de regresión de 161 decisiones de
`makeDecision` sobre un corpus fijo (MUS, DISCARD, apertura de
GRANDE/CHICA/PARES/JUEGO con marcador par/detrás/delante, y respuesta a
envite normal + órdago en variantes mano/postre/hailmary, para 6
arquetipos de mano). Cada caso usa una `AILogic` nueva con `rng` de
semilla fija → determinista e independiente del orden y de añadir casos.
Serializa solo acción + cartas (no el `debugLog`, que lleva UUID
aleatorio).

Vive en master, independiente del simulador (que está en otra rama y
mide calidad agregada, no paridad caso-a-caso). Es la prueba objetiva de
"decisiones de IA bit a bit idénticas" para los Tiers 1c/1d/1e y la
descomposición de AILogic (3b). Si cambia a propósito, se regenera desde
`app/build/ai-snapshot-actual.txt`.

## Verificación
- 55 tests, 3 skipped (@Ignore preexistentes), 0 fallos.
- `compileDebugKotlin` + `compileReleaseKotlin` verdes.
@