### PR TITLE
refactor(ai): gatear el log de decisión con DebugFeatures.IS_ENABLED

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -2,6 +2,7 @@ package com.doselfurioso.musvisto.logic
 
 import android.util.Log
 import com.doselfurioso.musvisto.R
+import com.doselfurioso.musvisto.debug.DebugFeatures
 import java.util.UUID
 import com.doselfurioso.musvisto.model.Card
 import com.doselfurioso.musvisto.model.GameAction
@@ -28,6 +29,18 @@ data class AIDecision(
     /** Log detallado de la decisión, consumido por el panel de debug en builds debug. */
     val debugLog: String = ""
 )
+
+/**
+ * Acumulador del log de decisión de la IA. En builds debug se comporta como
+ * un StringBuilder; en release es un no-op (no se asigna el StringBuilder ni
+ * crecen los appends), evitando el trabajo perdido que señala KNOWN_ISSUES.
+ * No afecta a ninguna decisión: el log es puramente informativo.
+ */
+private class DecisionLog {
+    private val sb: StringBuilder? = if (DebugFeatures.IS_ENABLED) StringBuilder() else null
+    fun appendLine(line: String) { sb?.appendLine(line) }
+    override fun toString(): String = sb?.toString() ?: ""
+}
 
 /**
  * Clase AILogic
@@ -59,7 +72,7 @@ class AILogic constructor(
     // ---------------- Public entry point ----------------
     fun makeDecision(gameState: GameState, aiPlayer: Player): AIDecision {
         val decisionId = UUID.randomUUID().toString().substring(0, 5)
-        val logBuilder = StringBuilder()
+        val logBuilder = DecisionLog()
 
         val rivalTeam = if (aiPlayer.team == "teamA") "teamB" else "teamA"
         val myScore = gameState.score[aiPlayer.team] ?: 0
@@ -201,8 +214,8 @@ class AILogic constructor(
             append(" -> ${decision.action.displayText}")
         }
         val log = "$tldr\n${logBuilder}"
-        Log.d(TAG, log)
-        return decision.copy(debugLog = log)
+        if (DebugFeatures.IS_ENABLED) Log.d(TAG, log)
+        return decision.copy(debugLog = if (DebugFeatures.IS_ENABLED) log else "")
     }
 
     private fun getPairingRank(rank: Rank): Rank {
@@ -891,7 +904,7 @@ class AILogic constructor(
         baseStrength: HandStrength,
         gameState: GameState,
         aiPlayer: Player,
-        logBuilder: StringBuilder
+        logBuilder: DecisionLog
     ): HandStrength {
         if (gameState.knownGestures.isEmpty()) {
             logBuilder.appendLine("2. No gestures remembered this round.")

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -3,7 +3,7 @@
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>CyclomaticComplexMethod:AILogic.kt$AILogic$fun makeDecision(gameState: GameState, aiPlayer: Player): AIDecision</ID>
-    <ID>CyclomaticComplexMethod:AILogic.kt$AILogic$private fun adjustStrengthsBasedOnKnownGestures( baseStrength: HandStrength, gameState: GameState, aiPlayer: Player, logBuilder: StringBuilder ): HandStrength</ID>
+    <ID>CyclomaticComplexMethod:AILogic.kt$AILogic$private fun adjustStrengthsBasedOnKnownGestures( baseStrength: HandStrength, gameState: GameState, aiPlayer: Player, logBuilder: DecisionLog ): HandStrength</ID>
     <ID>CyclomaticComplexMethod:AILogic.kt$AILogic$private fun decideInitialBet( strength: Int, aiPlayer: Player, gameState: GameState ): Pair&lt;GameAction, String&gt;</ID>
     <ID>CyclomaticComplexMethod:AILogic.kt$AILogic$private fun decideResponse( adjustedStrength: Int, gameState: GameState, aiPlayer: Player ): GameAction</ID>
     <ID>CyclomaticComplexMethod:AILogic.kt$AILogic$private fun evaluateHand(hand: List&lt;Card&gt;, player: Player, gameState: GameState): EvaluationResult</ID>
@@ -16,7 +16,7 @@
     <ID>LargeClass:AILogic.kt$AILogic</ID>
     <ID>LargeClass:MusGameLogic.kt$MusGameLogic</ID>
     <ID>LongMethod:AILogic.kt$AILogic$fun makeDecision(gameState: GameState, aiPlayer: Player): AIDecision</ID>
-    <ID>LongMethod:AILogic.kt$AILogic$private fun adjustStrengthsBasedOnKnownGestures( baseStrength: HandStrength, gameState: GameState, aiPlayer: Player, logBuilder: StringBuilder ): HandStrength</ID>
+    <ID>LongMethod:AILogic.kt$AILogic$private fun adjustStrengthsBasedOnKnownGestures( baseStrength: HandStrength, gameState: GameState, aiPlayer: Player, logBuilder: DecisionLog ): HandStrength</ID>
     <ID>LongMethod:AILogic.kt$AILogic$private fun evaluateHand(hand: List&lt;Card&gt;, player: Player, gameState: GameState): EvaluationResult</ID>
     <ID>LongMethod:GameScreen.kt$@Composable fun ActionButtons( actions: List&lt;GameAction&gt;, gamePhase: GamePhase, // &lt;-- Necesitamos saber la fase actual onActionClick: (GameAction, String) -&gt; Unit, selectedCardCount: Int, isEnabled: Boolean, currentPlayerId: String, isRaise: Boolean, modifier: Modifier = Modifier, dimens: ResponsiveDimens )</ID>
     <ID>LongMethod:GameScreen.kt$@Composable private fun PlayerAvatar( player: Player, isCurrentTurn: Boolean, // This will control the glow modifier: Modifier = Modifier, isMano: Boolean, hasCutMus: Boolean, activeGestureResId: Int?, discardCount: Int? = null, dimens: ResponsiveDimens )</ID>
@@ -199,7 +199,7 @@
     <ID>MaxLineLength:MusGameLogicTest.kt$MusGameLogicTest$val hand = listOf(Card(Suit.OROS, Rank.REY), Card(Suit.COPAS, Rank.TRES), Card(Suit.ESPADAS, Rank.SIETE), Card(Suit.BASTOS, Rank.CINCO))</ID>
     <ID>MaxLineLength:MusGameLogicTest.kt$MusGameLogicTest$val playerWith31 = players[0].copy(hand = listOf(Card(Suit.OROS, Rank.SOTA), Card(Suit.ESPADAS, Rank.SOTA), Card(Suit.COPAS, Rank.SOTA), Card(Suit.BASTOS, Rank.AS))) // 31</ID>
     <ID>MaxLineLength:MusGameLogicTest.kt$MusGameLogicTest$val playerWith32 = players[1].copy(hand = listOf(Card(Suit.OROS, Rank.SOTA), Card(Suit.ESPADAS, Rank.SOTA), Card(Suit.COPAS, Rank.SIETE), Card(Suit.BASTOS, Rank.CINCO))) // 32</ID>
-    <ID>NestedBlockDepth:AILogic.kt$AILogic$private fun adjustStrengthsBasedOnKnownGestures( baseStrength: HandStrength, gameState: GameState, aiPlayer: Player, logBuilder: StringBuilder ): HandStrength</ID>
+    <ID>NestedBlockDepth:AILogic.kt$AILogic$private fun adjustStrengthsBasedOnKnownGestures( baseStrength: HandStrength, gameState: GameState, aiPlayer: Player, logBuilder: DecisionLog ): HandStrength</ID>
     <ID>NestedBlockDepth:MusGameLogic.kt$MusGameLogic$fun scoreRound(currentState: GameState): GameState</ID>
     <ID>NewLineAtEndOfFile:AILogicTest.kt$com.doselfurioso.musvisto.logic.AILogicTest.kt</ID>
     <ID>NewLineAtEndOfFile:CardMapper.kt$com.doselfurioso.musvisto.presentation.CardMapper.kt</ID>


### PR DESCRIPTION
@
**Tier 1 / 1e** del refactor clean-code. Deuda sancionada en KNOWN_ISSUES.

`makeDecision` construía un `StringBuilder` verboso (~30 appends) y
llamaba `Log.d` en cada decisión también en builds release, donde nadie
lee el log → trabajo perdido y acumulable.

Cambio: wrapper `DecisionLog` con la MISMA API (`appendLine`/`toString`).
En debug es un `StringBuilder` real; en release no asigna nada y los
appends son no-op. `Log.d` y `debugLog` gateados con
`DebugFeatures.IS_ENABLED`. **No se toca ninguna línea de decisión.**

## Verificación
- Snapshot 0b (`AILogicSnapshotTest`, 161 decisiones) **byte-idéntico**
  → decisiones de IA sin cambio.
- Golden 0a + 55 tests verdes; `compileDebugKotlin` +
  `compileReleaseKotlin` verdes; `detekt` verde.
- `baseline.xml`: el delta es solo el re-key de 3 issues PREEXISTENTES de
  `adjustStrengthsBasedOnKnownGestures` (cambió el tipo del parámetro
  `logBuilder`); sin deuda nueva.
@