### PR TITLE
fix(ui): tope superior en el selector de envite (BetSelector)

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -82,6 +82,11 @@ private const val ANNOUNCEMENT_ENTER_MS = 200
 private const val ANNOUNCEMENT_EXIT_MS = 250
 private const val ANNOUNCEMENT_TEXT_FADE_MS = 180
 
+// Tope visual del selector de envite. Los envites normales van 2-5; por
+// encima de esto es territorio de órdago (botón aparte, 40). Evita envidar
+// cantidades arbitrarias con el botón "+".
+private const val MAX_BET = 30
+
 // Custom modifier for the bottom border (no changes here)
 @SuppressLint("UnnecessaryComposedModifier")
 fun Modifier.bottomBorder(strokeWidth: Dp, color: Color) = composed(
@@ -1424,7 +1429,7 @@ fun BetSelector(
                     fontSize = 32.sp,
                     fontWeight = FontWeight.Bold
                 )
-                Button(onClick = { betAmount++ }) {
+                Button(onClick = { if (betAmount < MAX_BET) betAmount++ }) {
                     Text("+", fontSize = 24.sp)
                 }
             }

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -82,10 +82,10 @@ private const val ANNOUNCEMENT_ENTER_MS = 200
 private const val ANNOUNCEMENT_EXIT_MS = 250
 private const val ANNOUNCEMENT_TEXT_FADE_MS = 180
 
-// Tope visual del selector de envite. Los envites normales van 2-5; por
-// encima de esto es territorio de órdago (botón aparte, 40). Evita envidar
-// cantidades arbitrarias con el botón "+".
-private const val MAX_BET = 30
+// Tope visual del selector de envite. En el Mus no hay límite real de
+// cuánto se puede envidar; lo acotamos al valor máximo de un juego (40 =
+// órdago / puntos para ganar). Evita envidar cantidades arbitrarias con "+".
+private const val MAX_BET = 40
 
 // Custom modifier for the bottom border (no changes here)
 @SuppressLint("UnnecessaryComposedModifier")


### PR DESCRIPTION
@
**Tier 1 / 1f** del refactor clean-code. Bug menor de KNOWN_ISSUES.

El botón `+` del `BetSelector` no tenía tope → se podía envidar
cantidades arbitrarias. Añadido `MAX_BET = 30` y guarda
`if (betAmount < MAX_BET)` en el `+`, espejando la guarda existente del
`-` (`if (betAmount > 2)`). Nada más.

## Verificación
- 55 tests, 0 fallos; goldens 0a/0b sin cambio (no se toca lógica/IA).
- `compileDebugKotlin` + `compileReleaseKotlin` + `detekt` verdes.
- `compose-ui-reviewer`: sin riesgos de recomposición/estado/timing.
- **UI → requiere tu playtest** antes de mergear (no auto-mergeado).
@