### PR TITLE
fix(ai): #13 escalar el bonus de mano en Pares por rango

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -734,8 +734,9 @@ class AILogic constructor(
                 paresStrength = 20 + rankValue.value * 3
                 explanation.appendLine("     - Base por Pares de ${paresPlay.rank.name} (valor $rankValue) -> $paresStrength pts")
                 if (isMano) {
-                    paresStrength += 15
-                    explanation.appendLine("     - Bonus por ser Mano -> +15 pts")
+                    val manoBonus = manoParesBonus(rankValue.value)
+                    paresStrength += manoBonus
+                    explanation.appendLine("     - Bonus por ser Mano (escalado #13) -> +$manoBonus pts")
                 }
             }
 
@@ -1048,6 +1049,25 @@ class AILogic constructor(
         else -> 0
     }
 
+    /**
+     * Bonus de fuerza por ser MANO en un PAR ÚNICO, escalado por rango (#13).
+     * Ser mano en Pares solo gana empates de mismo rango: en pares bajos
+     * (4-7) eso es raro y barato → prima ≈0; en Rey/Tres el empate al tope es
+     * frecuente y caro → +15 íntegro (techo intacto, sin regresión). Sustituye
+     * al antiguo +15 plano que inflaba pares bajos sobre el umbral de corte de
+     * Mus. Curva recomendada por mus-strategy-reviewer. NO aplica a
+     * Duples/Medias (fuera del alcance de #13).
+     */
+    @Suppress("MagicNumber") // Tabla heurística de IA: los valores SON la curva.
+    private fun manoParesBonus(pairingRankValue: Int): Int = when {
+        pairingRankValue <= 5  -> 0      // As/Dos..Cinco
+        pairingRankValue == 6  -> 1      // Seis
+        pairingRankValue == 7  -> 2      // Siete
+        pairingRankValue <= 10 -> 8      // Sota
+        pairingRankValue == 11 -> 11     // Caballo
+        else -> 15                       // Rey/Tres
+    }
+
     private fun getParesPlayStrength(paresPlay: ParesPlay, isMano: Boolean): Int {
         var strength = when (paresPlay) {
             is ParesPlay.Duples -> duplesStrength(paresPlay)
@@ -1055,8 +1075,13 @@ class AILogic constructor(
             is ParesPlay.Pares -> 20 + (getPairingRankValue(paresPlay.rank) * 3)
             is ParesPlay.NoPares -> 0
         }
-        if (isMano && paresPlay !is ParesPlay.NoPares) {
-            strength += 15
+        if (isMano) {
+            strength += when (paresPlay) {
+                // #13: par único escalado por rango; Duples/Medias siguen +15.
+                is ParesPlay.Pares -> manoParesBonus(getPairingRankValue(paresPlay.rank))
+                is ParesPlay.NoPares -> 0
+                else -> 15
+            }
         }
         return strength.coerceIn(0, 100)
     }

--- a/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicSnapshotTest.kt
+++ b/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicSnapshotTest.kt
@@ -36,10 +36,24 @@ class AILogicSnapshotTest {
     private val weak = listOf(c(Suit.OROS, Rank.REY), c(Suit.COPAS, Rank.SOTA), c(Suit.ESPADAS, Rank.CUATRO), c(Suit.BASTOS, Rank.AS))
     private val lowChica = listOf(c(Suit.OROS, Rank.AS), c(Suit.COPAS, Rank.CUATRO), c(Suit.ESPADAS, Rank.CINCO), c(Suit.BASTOS, Rank.SEIS))
     private val medium = listOf(c(Suit.OROS, Rank.REY), c(Suit.COPAS, Rank.CABALLO), c(Suit.ESPADAS, Rank.SIETE), c(Suit.BASTOS, Rank.CUATRO))
+    // Pares únicos (cobertura de #13: bonus de mano escalado por rango).
+    private val par7 = listOf(
+        c(Suit.OROS, Rank.SIETE), c(Suit.COPAS, Rank.SIETE),
+        c(Suit.ESPADAS, Rank.CUATRO), c(Suit.BASTOS, Rank.CINCO)
+    )
+    private val parAs = listOf(
+        c(Suit.OROS, Rank.AS), c(Suit.COPAS, Rank.AS),
+        c(Suit.ESPADAS, Rank.CUATRO), c(Suit.BASTOS, Rank.CINCO)
+    )
+    private val parRey = listOf(
+        c(Suit.OROS, Rank.REY), c(Suit.COPAS, Rank.REY),
+        c(Suit.ESPADAS, Rank.CUATRO), c(Suit.BASTOS, Rank.CINCO)
+    )
 
     private val archetypes = listOf(
         "4REY" to fourKings, "J31" to juego31, "DUP" to duplesRC,
-        "WEAK" to weak, "LOWC" to lowChica, "MED" to medium
+        "WEAK" to weak, "LOWC" to lowChica, "MED" to medium,
+        "P7" to par7, "PAS" to parAs, "PREY" to parRey
     )
 
     /** ai = p2 (teamB). Compañero p4 (teamB). Rivales p1/p3 (teamA). */
@@ -158,6 +172,15 @@ DISCARD/LOWC => ConfirmDiscard [BSE,CCU,ECI,OAS]
 MUS/MED/mano=p2 => NoMus
 MUS/MED/mano=p4 => NoMus
 DISCARD/MED => ConfirmDiscard [BCU]
+MUS/P7/mano=p2 => Mus
+MUS/P7/mano=p4 => Mus
+DISCARD/P7 => ConfirmDiscard [BCI,CSI,ECU,OSI]
+MUS/PAS/mano=p2 => Mus
+MUS/PAS/mano=p4 => Mus
+DISCARD/PAS => ConfirmDiscard [BCI,ECU]
+MUS/PREY/mano=p2 => Mus
+MUS/PREY/mano=p4 => Mus
+DISCARD/PREY => ConfirmDiscard [BCI,ECU]
 OPEN/GRANDE/4REY/par => Envido(5)
 OPEN/GRANDE/4REY/detras => Órdago
 OPEN/GRANDE/4REY/delante => Envido(4)
@@ -230,6 +253,42 @@ OPEN/PARES/MED/delante => Paso
 OPEN/JUEGO/MED/par => Envido(5)
 OPEN/JUEGO/MED/detras => Órdago
 OPEN/JUEGO/MED/delante => Envido(4)
+OPEN/GRANDE/P7/par => Paso
+OPEN/GRANDE/P7/detras => Paso
+OPEN/GRANDE/P7/delante => Paso
+OPEN/CHICA/P7/par => Paso
+OPEN/CHICA/P7/detras => Paso
+OPEN/CHICA/P7/delante => Paso
+OPEN/PARES/P7/par => Paso
+OPEN/PARES/P7/detras => Paso
+OPEN/PARES/P7/delante => Paso
+OPEN/JUEGO/P7/par => Paso
+OPEN/JUEGO/P7/detras => Paso
+OPEN/JUEGO/P7/delante => Paso
+OPEN/GRANDE/PAS/par => Paso
+OPEN/GRANDE/PAS/detras => Paso
+OPEN/GRANDE/PAS/delante => Paso
+OPEN/CHICA/PAS/par => Envido(3)
+OPEN/CHICA/PAS/detras => Órdago
+OPEN/CHICA/PAS/delante => Paso
+OPEN/PARES/PAS/par => Paso
+OPEN/PARES/PAS/detras => Paso
+OPEN/PARES/PAS/delante => Paso
+OPEN/JUEGO/PAS/par => Paso
+OPEN/JUEGO/PAS/detras => Paso
+OPEN/JUEGO/PAS/delante => Paso
+OPEN/GRANDE/PREY/par => Envido(3)
+OPEN/GRANDE/PREY/detras => Órdago
+OPEN/GRANDE/PREY/delante => Paso
+OPEN/CHICA/PREY/par => Paso
+OPEN/CHICA/PREY/detras => Paso
+OPEN/CHICA/PREY/delante => Paso
+OPEN/PARES/PREY/par => Envido(3)
+OPEN/PARES/PREY/detras => Órdago
+OPEN/PARES/PREY/delante => Paso
+OPEN/JUEGO/PREY/par => Paso
+OPEN/JUEGO/PREY/detras => Paso
+OPEN/JUEGO/PREY/delante => Paso
 RESP/GRANDE/4REY/bet/mano => Envido(5)
 RESP/GRANDE/4REY/bet/postre => Envido(5)
 RESP/GRANDE/4REY/ordago/even => Quiero
@@ -302,6 +361,42 @@ RESP/JUEGO/MED/bet/mano => Envido(5)
 RESP/JUEGO/MED/bet/postre => Quiero
 RESP/JUEGO/MED/ordago/even => Quiero
 RESP/JUEGO/MED/ordago/hailmary => Quiero
+RESP/GRANDE/P7/bet/mano => NoQuiero
+RESP/GRANDE/P7/bet/postre => NoQuiero
+RESP/GRANDE/P7/ordago/even => NoQuiero
+RESP/GRANDE/P7/ordago/hailmary => Quiero
+RESP/PARES/P7/bet/mano => NoQuiero
+RESP/PARES/P7/bet/postre => NoQuiero
+RESP/PARES/P7/ordago/even => NoQuiero
+RESP/PARES/P7/ordago/hailmary => Quiero
+RESP/JUEGO/P7/bet/mano => NoQuiero
+RESP/JUEGO/P7/bet/postre => NoQuiero
+RESP/JUEGO/P7/ordago/even => NoQuiero
+RESP/JUEGO/P7/ordago/hailmary => Quiero
+RESP/GRANDE/PAS/bet/mano => NoQuiero
+RESP/GRANDE/PAS/bet/postre => NoQuiero
+RESP/GRANDE/PAS/ordago/even => NoQuiero
+RESP/GRANDE/PAS/ordago/hailmary => Quiero
+RESP/PARES/PAS/bet/mano => NoQuiero
+RESP/PARES/PAS/bet/postre => NoQuiero
+RESP/PARES/PAS/ordago/even => NoQuiero
+RESP/PARES/PAS/ordago/hailmary => Quiero
+RESP/JUEGO/PAS/bet/mano => NoQuiero
+RESP/JUEGO/PAS/bet/postre => NoQuiero
+RESP/JUEGO/PAS/ordago/even => NoQuiero
+RESP/JUEGO/PAS/ordago/hailmary => Quiero
+RESP/GRANDE/PREY/bet/mano => NoQuiero
+RESP/GRANDE/PREY/bet/postre => NoQuiero
+RESP/GRANDE/PREY/ordago/even => NoQuiero
+RESP/GRANDE/PREY/ordago/hailmary => Quiero
+RESP/PARES/PREY/bet/mano => NoQuiero
+RESP/PARES/PREY/bet/postre => NoQuiero
+RESP/PARES/PREY/ordago/even => NoQuiero
+RESP/PARES/PREY/ordago/hailmary => Quiero
+RESP/JUEGO/PREY/bet/mano => NoQuiero
+RESP/JUEGO/PREY/bet/postre => NoQuiero
+RESP/JUEGO/PREY/ordago/even => NoQuiero
+RESP/JUEGO/PREY/ordago/hailmary => Quiero
 """.trimIndent()
     }
 }


### PR DESCRIPTION
@
**Cadena de IA #13.** El `+15` plano de "ser mano" en Pares inflaba pares
bajos sobre el umbral de corte de Mus / envite (par de 7 mano: 41→56) →
cortaba Mus / sobre-apostaba con pares bajos fuera de desesperación.

Sustituido por `manoParesBonus()`: curva por tabla (recomendada por
`mus-strategy-reviewer`) ≈0 hasta el 7, +15 en Rey/Tres (**techo intacto
→ cero regresión arriba**). Solo par único; Duples (curado en #12) y
Medias intactos. Aplicado en `evaluateHand` y `getParesPlayStrength`.

Snapshot 0b: corpus ampliado con pares únicos (P7/PAS/PREY) y golden
regenerado **a propósito** (P7 deja de abrir Pares de mano; PREY
idéntico al +15 previo, sin regresión).

## Validación
- `testDebugUnitTest` verde (4 clases) + `detekt` + ambas variantes.
- **Simulador** (200 partidas, seeds 0-199, rama de medición sobre
  master): aceptar-quiero neto **−306 → −270 (+36)**, showdown envites
  74.2% → 74.4%, aperturas de Pares 873 → 853 (se eliminan los envites
  malos de pares bajos de mano sin perder calidad), corte de Mus = 27.4%
  (sin regresión). Cumple los criterios del `mus-strategy-reviewer`.
- Pendiente: playtest del usuario con el editor de escenarios (par de 7
  de mano → debe pedir Mus).
@