### PR TITLE
refactor(ai): 3b-iii descomponer el dispatch de makeDecision

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -128,9 +128,6 @@ class AILogic constructor(
         logBuilder.appendLine("4. Final Strength -> $finalLine")
         logBuilder.appendLine("-------------------------------------------------")
 
-        val decision: AIDecision
-        val actionLog: String
-
         // Capitanía de lance (#1/#4): ¿debo jugar de apoyo y cederle la
         // iniciativa al compañero (mejor posición + seña fuerte conocida)?
         val ownBaseLance = when (gameState.gamePhase) {
@@ -143,61 +140,10 @@ class AILogic constructor(
         val playSupport = shouldPlaySupport(gameState, aiPlayer, gameState.gamePhase, ownBaseLance)
         if (playSupport) logBuilder.appendLine("4b. Rol de APOYO: compañero capitán de lance (mejor posición + seña fuerte), mano propia floja ($ownBaseLance).")
 
-        if (gameState.currentBet != null) {
-            val strengthForLance = when (gameState.gamePhase) {
-                GamePhase.GRANDE -> finalStrength.grande
-                GamePhase.CHICA -> finalStrength.chica
-                GamePhase.PARES -> finalStrength.pares
-                GamePhase.JUEGO -> finalStrength.juego
-                else -> 0
-            }
-            val rawResponse = decideResponse(strengthForLance, gameState, aiPlayer)
-            // En apoyo no escalo: una subida (Envido/Órdago) se rebaja a Quiero
-            // para mantener el bote del equipo sin pisar al capitán.
-            val responseAction = if (playSupport &&
-                (rawResponse is GameAction.Envido || rawResponse is GameAction.Órdago)
-            ) GameAction.Quiero else rawResponse
-            decision = AIDecision(responseAction)
-            val threshold = 70 // Umbral para "Quiero"
-            actionLog = when {
-                playSupport && responseAction !== rawResponse ->
-                    ">>> FINAL ACTION: Quiero (Apoyo: rebajado desde ${rawResponse.displayText} para no pisar al capitán)"
-                responseAction is GameAction.Quiero ->
-                    ">>> FINAL ACTION: Quiero (Reason: Strength $strengthForLance >= threshold $threshold)"
-                else ->
-                    ">>> FINAL ACTION: ${responseAction.displayText} (Reason: Strength $strengthForLance < threshold $threshold)"
-            }
+        val (decision, actionLog) = if (gameState.currentBet != null) {
+            decideBettingResponse(gameState, aiPlayer, finalStrength, playSupport)
         } else {
-            when (gameState.gamePhase) {
-                GamePhase.MUS -> {
-                    val musResult = decideMus(finalStrength, aiPlayer, riskFactor, gameState)
-                    decision = AIDecision(musResult.first)
-                    actionLog = ">>> FINAL ACTION: ${musResult.first.displayText} (${musResult.second})"
-                }
-                GamePhase.DISCARD -> {
-                    decision = decideDiscard(aiPlayer)
-                    actionLog = ">>> FINAL ACTION: ${decision.action.displayText} (Cards: ${decision.cardsToDiscard.joinToString { cardToShortString(it) }})"
-                }
-                else -> {
-                    val strengthForLance = when(gameState.gamePhase) {
-                        GamePhase.GRANDE -> finalStrength.grande
-                        GamePhase.CHICA -> finalStrength.chica
-                        GamePhase.PARES -> finalStrength.pares
-                        else -> finalStrength.juego
-                    }
-                    val betResult = decideInitialBet(strengthForLance, aiPlayer, gameState)
-                    // En apoyo no abro: dejo hablar a rivales y al capitán.
-                    val betAction = if (playSupport &&
-                        (betResult.first is GameAction.Envido || betResult.first is GameAction.Órdago)
-                    ) GameAction.Paso else betResult.first
-                    decision = AIDecision(betAction)
-                    actionLog = if (playSupport && betAction !== betResult.first) {
-                        ">>> FINAL ACTION: Paso (Apoyo: no abro desde mala posición, cedo al capitán; era ${betResult.first.displayText})"
-                    } else {
-                        ">>> FINAL ACTION: ${betResult.first.displayText} (${betResult.second})"
-                    }
-                }
-            }
+            decideByPhase(gameState, aiPlayer, finalStrength, riskFactor, playSupport)
         }
 
         logBuilder.appendLine(actionLog)
@@ -221,6 +167,79 @@ class AILogic constructor(
         val log = "$tldr\n${logBuilder}"
         if (DebugFeatures.IS_ENABLED) Log.d(TAG, log)
         return decision.copy(debugLog = if (DebugFeatures.IS_ENABLED) log else "")
+    }
+
+    /** Responder a una apuesta activa. Devuelve (decisión, línea de log). */
+    private fun decideBettingResponse(
+        gameState: GameState,
+        aiPlayer: Player,
+        finalStrength: HandStrength,
+        playSupport: Boolean
+    ): Pair<AIDecision, String> {
+        val strengthForLance = when (gameState.gamePhase) {
+            GamePhase.GRANDE -> finalStrength.grande
+            GamePhase.CHICA -> finalStrength.chica
+            GamePhase.PARES -> finalStrength.pares
+            GamePhase.JUEGO -> finalStrength.juego
+            else -> 0
+        }
+        val rawResponse = decideResponse(strengthForLance, gameState, aiPlayer)
+        // En apoyo no escalo: una subida (Envido/Órdago) se rebaja a Quiero
+        // para mantener el bote del equipo sin pisar al capitán.
+        val responseAction = if (playSupport &&
+            (rawResponse is GameAction.Envido || rawResponse is GameAction.Órdago)
+        ) GameAction.Quiero else rawResponse
+        val threshold = 70 // Umbral para "Quiero"
+        val actionLog = when {
+            playSupport && responseAction !== rawResponse ->
+                ">>> FINAL ACTION: Quiero (Apoyo: rebajado desde ${rawResponse.displayText} para no pisar al capitán)"
+            responseAction is GameAction.Quiero ->
+                ">>> FINAL ACTION: Quiero (Reason: Strength $strengthForLance >= threshold $threshold)"
+            else ->
+                ">>> FINAL ACTION: ${responseAction.displayText} (Reason: Strength $strengthForLance < threshold $threshold)"
+        }
+        return AIDecision(responseAction) to actionLog
+    }
+
+    /** Decisión sin apuesta activa: MUS / DISCARD / apertura de lance. */
+    private fun decideByPhase(
+        gameState: GameState,
+        aiPlayer: Player,
+        finalStrength: HandStrength,
+        riskFactor: Int,
+        playSupport: Boolean
+    ): Pair<AIDecision, String> {
+        when (gameState.gamePhase) {
+            GamePhase.MUS -> {
+                val musResult = decideMus(finalStrength, aiPlayer, riskFactor, gameState)
+                return AIDecision(musResult.first) to
+                    ">>> FINAL ACTION: ${musResult.first.displayText} (${musResult.second})"
+            }
+            GamePhase.DISCARD -> {
+                val decision = decideDiscard(aiPlayer)
+                return decision to
+                    ">>> FINAL ACTION: ${decision.action.displayText} (Cards: ${decision.cardsToDiscard.joinToString { cardToShortString(it) }})"
+            }
+            else -> {
+                val strengthForLance = when(gameState.gamePhase) {
+                    GamePhase.GRANDE -> finalStrength.grande
+                    GamePhase.CHICA -> finalStrength.chica
+                    GamePhase.PARES -> finalStrength.pares
+                    else -> finalStrength.juego
+                }
+                val betResult = decideInitialBet(strengthForLance, aiPlayer, gameState)
+                // En apoyo no abro: dejo hablar a rivales y al capitán.
+                val betAction = if (playSupport &&
+                    (betResult.first is GameAction.Envido || betResult.first is GameAction.Órdago)
+                ) GameAction.Paso else betResult.first
+                val actionLog = if (playSupport && betAction !== betResult.first) {
+                    ">>> FINAL ACTION: Paso (Apoyo: no abro desde mala posición, cedo al capitán; era ${betResult.first.displayText})"
+                } else {
+                    ">>> FINAL ACTION: ${betResult.first.displayText} (${betResult.second})"
+                }
+                return AIDecision(betAction) to actionLog
+            }
+        }
     }
 
     private fun getPairingRank(rank: Rank): Rank {

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -221,6 +221,9 @@ class AILogic constructor(
                     ">>> FINAL ACTION: ${decision.action.displayText} (Cards: ${decision.cardsToDiscard.joinToString { cardToShortString(it) }})"
             }
             else -> {
+                // Intencional: en APERTURA el `else` cae a juego (la rama
+                // else de fase aquí es JUEGO). En decideBettingResponse el
+                // `else` es 0 (allí puede haber fases sin lance). NO unificar.
                 val strengthForLance = when(gameState.gamePhase) {
                     GamePhase.GRANDE -> finalStrength.grande
                     GamePhase.CHICA -> finalStrength.chica

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -12,7 +12,6 @@
     <ID>CyclomaticComplexMethod:MusGameLogic.kt$MusGameLogic$fun scoreRound(currentState: GameState): GameState</ID>
     <ID>LargeClass:AILogic.kt$AILogic</ID>
     <ID>LargeClass:MusGameLogic.kt$MusGameLogic</ID>
-    <ID>LongMethod:AILogic.kt$AILogic$fun makeDecision(gameState: GameState, aiPlayer: Player): AIDecision</ID>
     <ID>LongMethod:GameScreen.kt$@Composable fun ActionButtons( actions: List&lt;GameAction&gt;, gamePhase: GamePhase, // &lt;-- Necesitamos saber la fase actual onActionClick: (GameAction, String) -&gt; Unit, selectedCardCount: Int, isEnabled: Boolean, currentPlayerId: String, isRaise: Boolean, modifier: Modifier = Modifier, dimens: ResponsiveDimens )</ID>
     <ID>LongMethod:GameScreen.kt$@Composable private fun PlayerAvatar( player: Player, isCurrentTurn: Boolean, // This will control the glow modifier: Modifier = Modifier, isMano: Boolean, hasCutMus: Boolean, activeGestureResId: Int?, discardCount: Int? = null, dimens: ResponsiveDimens )</ID>
     <ID>LongMethod:GameScreen.kt$@SuppressLint("UnusedBoxWithConstraintsScope") @Composable fun GameScreen( gameViewModel: GameViewModel, navController: NavController )</ID>
@@ -111,10 +110,9 @@
     <ID>MagicNumber:MusGameLogic.kt$MusGameLogic$31</ID>
     <ID>MagicNumber:MusGameLogic.kt$MusGameLogic$32</ID>
     <ID>MagicNumber:MusGameLogic.kt$MusGameLogic$40</ID>
+    <ID>MaxLineLength:AILogic.kt$AILogic$"&gt;&gt;&gt; FINAL ACTION: ${decision.action.displayText} (Cards: ${decision.cardsToDiscard.joinToString { cardToShortString(it) }})"</ID>
     <ID>MaxLineLength:AILogic.kt$AILogic$"&gt;&gt;&gt; FINAL ACTION: ${responseAction.displayText} (Reason: Strength $strengthForLance &lt; threshold $threshold)"</ID>
     <ID>MaxLineLength:AILogic.kt$AILogic$"&gt;&gt;&gt; FINAL ACTION: Paso (Apoyo: no abro desde mala posición, cedo al capitán; era ${betResult.first.displayText})"</ID>
-    <ID>MaxLineLength:AILogic.kt$AILogic$"&gt;&gt;&gt; FINAL ACTION: Quiero (Apoyo: rebajado desde ${rawResponse.displayText} para no pisar al capitán)"</ID>
-    <ID>MaxLineLength:AILogic.kt$AILogic$actionLog = "&gt;&gt;&gt; FINAL ACTION: ${decision.action.displayText} (Cards: ${decision.cardsToDiscard.joinToString { cardToShortString(it) }})"</ID>
     <ID>MaxLineLength:AILogic.kt$AILogic$explanation.appendLine(" - 31 sin ser mano, $rivalsAhead rival(es) delante (P perder ${(pLose * 100).toInt()}%) -&gt; -$posPenalty pts")</ID>
     <ID>MaxLineLength:AILogic.kt$AILogic$explanation.appendLine(" - Base por Pares de ${paresPlay.rank.name} (valor $rankValue) -&gt; $paresStrength pts")</ID>
     <ID>MaxLineLength:AILogic.kt$AILogic$explanation.appendLine(" - Bonus por carta más baja (${cardToShortString(bestChicaCard)}) -&gt; +$bonus pts")</ID>


### PR DESCRIPTION
@
**Tier 3b / 3b-iii** del refactor clean-code. Comportamiento-cero.

El bloque de dispatch de `makeDecision` (~56 líneas: if currentBet /
when phase) → `decideBettingResponse` + `decideByPhase` (ambas devuelven
`(AIDecision, actionLog)`). `makeDecision` queda como orquestador legible
(eval → señas → riskFactor → finalStrength → support → dispatch →
log/TLDR). Cuerpos verbatim; comentario guarda (sugerido por el reviewer)
sobre la divergencia intencionada de `strengthForLance` (else→juego en
apertura vs else→0 en respuesta).

## Verificación (comportamiento-cero por 4 vías)
- **Snapshot 0b** (161+ decisiones) **byte-idéntico**.
- 55 tests, 0 fallos; ambas variantes + `detekt` verdes.
- **Paridad de simulador** (200 partidas): agregados **IDÉNTICOS**.
- `mus-rules-reviewer`: **equivalente bit a bit** (dispatch, strengthForLance
  por fase, ajuste de apoyo, textos actionLog, riskFactor — todo preservado).
- `baseline.xml`: re-key de 1 línea larga preexistente + poda de
  `LongMethod:makeDecision` (resuelto); sin deuda nueva.
@