### PR TITLE
fix(ui): badge de descarte acotado al ciclo de Mus/descarte

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/logic/MusGameLogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/MusGameLogic.kt
@@ -463,7 +463,11 @@ class MusGameLogic constructor(private val random: Random){
                 currentTurnPlayerId = newState.manoPlayerId,
                 isNewLance = true,
                 currentLanceActions = emptyMap(),
-                knownGestures = emptyMap()
+                knownGestures = emptyMap(),
+                // Cada ciclo de descarte arranca limpio: el badge refleja
+                // SOLO este ciclo (fix multi-ronda: la 2ª ronda no arrastra
+                // los conteos de la 1ª).
+                discardCounts = emptyMap()
             )
         } else {
             // If not, it's the next player's turn to decide on Mus
@@ -476,11 +480,11 @@ class MusGameLogic constructor(private val random: Random){
             gamePhase = GamePhase.GRANDE,
             availableActions = listOf(GameAction.Paso, GameAction.Envido(2), GameAction.Órdago),
             playersWhoPassed = emptySet(),
-            // NO vaciamos discardCounts aquí: debe sobrevivir todo el resto de
-            // la ronda para que el indicador de descarte del avatar diga
-            // cuántas cartas tomó cada jugador. Se resetea solo en el reparto
-            // de la ronda siguiente (startNewRound construye un GameState nuevo
-            // con discardCounts por defecto vacío).
+            // Cerrado el Mus, los descartes ya no son relevantes: el badge
+            // del avatar desaparece al entrar en GRANDE (revisión de #27:
+            // antes vivía toda la ronda; el usuario lo quiere acotado a la
+            // fase de Mus/descarte).
+            discardCounts = emptyMap(),
             currentBet = null,
             currentTurnPlayerId = currentState.manoPlayerId,
             isNewLance = true,

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameScreen.kt
@@ -778,11 +778,11 @@ private fun PlayerAvatar(
             )
         }
 
-        // Indicador PERSISTENTE de descarte: cuántas cartas cambió este
-        // jugador en el Mus. Vive toda la ronda (discardCounts no se vacía
-        // hasta el reparto siguiente), por eso es un badge del avatar y no
-        // una burbuja de anuncio (esas se limpian por lance). Esquina libre
-        // (mano = abajo-dcha, corta-mus = abajo-izda, seña = centro).
+        // Badge de descarte: cuántas cartas cambió este jugador en el ciclo
+        // de Mus/descarte ACTUAL. Acotado a la fase de Mus/descarte
+        // (discardCounts se vacía al entrar en GRANDE y al iniciar cada
+        // ciclo de descarte). Esquina libre (mano = abajo-dcha, corta-mus =
+        // abajo-izda, seña = centro).
         if (discardCount != null && discardCount > 0) {
             Row(
                 modifier = Modifier


### PR DESCRIPTION
@
Reportado por el usuario. Revisión de la parte de #27 "vive toda la
ronda".

**Dos problemas, una causa raíz:** `discardCounts` no se vaciaba nunca
entre el fin de los descartes y el fin de la ronda.
- (a) **Bug multi-ronda:** con más de una ronda de Mus→descarte, el
  badge arrastraba los conteos de la 1ª (stale, "no se actualiza"). Fix:
  `handleMus` vacía `discardCounts` al entrar en DISCARD → cada ciclo
  arranca limpio.
- (b) **Desaparece tras el Mus:** `handleNoMus` vacía `discardCounts` al
  entrar en GRANDE → el badge ya no persiste por toda la ronda (decisión
  del usuario; visible solo en MUS/DISCARD).

Comportamiento confirmado por el usuario: visible durante MUS/DISCARD
(incl. deliberación de Mus tras descartar), resetea cada ciclo,
desaparece en GRANDE.

## Verificación
- **Golden 0a** (`MusGameLogicFlowTest`) **byte-idéntico** (el vaciado es
  no-op en escenarios NoMus-directo). Snapshot 0b intacto. 55 tests +
  ambas variantes + detekt verdes.
- Badge visible = UI → **requiere tu playtest** (forzar 2 rondas de
  descarte con el editor de escenarios `startAtMus`): el contador debe
  actualizarse en la 2ª y desaparecer al entrar en GRANDE.
@