### PR TITLE
fix(ai): #20 capitanía delegada del corte de Mus (solo compañero humano)

### DIFF
--- a/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
+++ b/app/src/debug/java/com/doselfurioso/musvisto/debug/DebugFeatures.kt
@@ -307,6 +307,25 @@ object DebugScenarios {
                 "p4" to listOf(c(Suit.BASTOS, Rank.REY), c(Suit.BASTOS, Rank.CABALLO), c(Suit.BASTOS, Rank.SOTA), c(Suit.BASTOS, Rank.CUATRO))
             ),
             manoId = "p1"
+        ),
+        DebugScenario(
+            // #20 humano-capitán: mano = p3 (tu pareja IA) -> orden de turno
+            // [p3, p4, p1, p2], así p1 (tú) actúas DESPUÉS que p3 = eres el
+            // CAPITÁN de tu pareja. p3 lleva 3 Reyes (premium, cortaría el Mus
+            // normalmente y seña reyes_3): con #20 NO corta, te delega el
+            // corte y te pasa la seña (visible 1.5s). Tu mano es floja a
+            // propósito: la decisión de cortar depende de leer la seña de p3.
+            // ~12% de las veces p3 cortará igual (estrategia mixta anti-patrón)
+            // -> también es comportamiento esperado a observar.
+            name = "#20 Humano capitán: IA-primero (p3) delega el corte",
+            hands = mapOf(
+                "p3" to listOf(c(Suit.OROS, Rank.REY), c(Suit.COPAS, Rank.REY), c(Suit.ESPADAS, Rank.REY), c(Suit.BASTOS, Rank.SOTA)),
+                "p1" to listOf(c(Suit.OROS, Rank.SOTA), c(Suit.COPAS, Rank.SIETE), c(Suit.ESPADAS, Rank.SEIS), c(Suit.BASTOS, Rank.CUATRO)),
+                "p4" to listOf(c(Suit.OROS, Rank.CABALLO), c(Suit.COPAS, Rank.CINCO), c(Suit.ESPADAS, Rank.CUATRO), c(Suit.BASTOS, Rank.DOS)),
+                "p2" to listOf(c(Suit.COPAS, Rank.CABALLO), c(Suit.ESPADAS, Rank.SOTA), c(Suit.OROS, Rank.TRES), c(Suit.BASTOS, Rank.AS))
+            ),
+            manoId = "p3",
+            startAtMus = true
         )
     )
 }

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -36,17 +36,16 @@ private const val MUS_CUT_PARES_JUEGO = 75
 private const val MUS_CUT_GRANDE_CHICA = 85
 // Si el COMPAÑERO es mano, sube el listón de corte (no quitarle la mano).
 private const val PARTNER_MANO_MUS_BIAS = 10
-// #20 Capitanía delegada de Mus: si actúo ANTES que mi compañero, le delego
-// el corte (es el capitán). Sesgo a pedir Mus subiendo el umbral de corte.
-private const val MUS_DELEGATION_BIAS = 8
-// Capitán = IA: las manos premium (nuts) las corto yo igualmente, no se
-// delegan (válvula EV: delegar la nuts y que el capitán dé Mus tira un
-// ganador). No aplica si el capitán es humano (su experiencia prima).
-private const val MUS_NUTS_FLOOR = 90
-// Capitán = humano: delegación dura (no corto), PERO estrategia mixta
-// anti-lectura: de vez en cuando, con jugada buena, corto igual para que el
-// rival no cante el patrón "el primero nunca corta". % y suelo provisionales,
-// a afinar con simulador/playtest (no fijar a ojo).
+// #20 Capitanía delegada de Mus: si actúo ANTES que mi compañero y este es
+// HUMANO, le delego el corte (es el capitán; lo decide él viendo mi seña).
+// Solo con compañero humano: el simulador probó que delegar IA->IA sangra
+// tantos a cualquier magnitud (la seña sub-transporta la fuerza de corte y el
+// capitán IA no la recupera), sin ningún beneficio de experiencia. Con
+// compañero IA #20 es no-op (comportamiento-cero, gate del simulador verde).
+// Estrategia mixta anti-lectura: de vez en cuando, con jugada buena, corto
+// igual para que no se cante el patrón "el primero nunca corta". % y suelo
+// provisionales, a afinar con playtest (el simulador IA->IA no mide esta
+// rama; no fijar a ojo).
 private const val MUS_DELEGATION_BREAK_PCT = 12
 private const val MUS_DELEGATION_BREAK_FLOOR = 70
 // Apertura de envite por bandas: > fuerte = valor seguro; [piso..fuerte] =
@@ -447,23 +446,18 @@ class AILogic constructor(
         val partnerIsMano = partner != null && gameState.manoPlayerId == partner.id
         val manoBias = if (partnerIsMano) PARTNER_MANO_MUS_BIAS else 0
 
-        // Capitanía delegada (#20): el corte del Mus lo lidera el CAPITÁN (el
-        // que actúa DESPUÉS). Si actúo ANTES, le delego el corte. El override
-        // resuelve los casos de delegación; null = seguir con los umbrales.
+        // Capitanía delegada (#20): si actúo ANTES que mi compañero y este es
+        // HUMANO, le delego el corte (lo decide él viendo mi seña). Con
+        // compañero IA -> null (comportamiento-cero; ver constantes #20).
         val iActBeforePartner = actsBeforePartner(gameState, aiPlayer, partner)
         val partnerIsAi = partner?.isAi == true
         val bestStrength = maxOf(strength.pares, strength.juego, strength.grande, strength.chica)
         decideMusDelegation(iActBeforePartner, partnerIsAi, bestStrength)?.let { return it }
 
-        // Capitán-IA con mano no-premium: delego la banda media subiendo el
-        // umbral. Si soy el capitán (actúo después) bias = 0 -> lógica de
-        // siempre (comportamiento-cero para el capitán).
-        val delegationBias = if (iActBeforePartner) MUS_DELEGATION_BIAS else 0
-
-        val paresCutThreshold = MUS_CUT_PARES_JUEGO - riskFactor + manoBias + delegationBias
-        val juegoCutThreshold = MUS_CUT_PARES_JUEGO - riskFactor + manoBias + delegationBias
-        val grandeCutThreshold = MUS_CUT_GRANDE_CHICA - riskFactor + manoBias + delegationBias
-        val chicaCutThreshold = MUS_CUT_GRANDE_CHICA - riskFactor + manoBias + delegationBias
+        val paresCutThreshold = MUS_CUT_PARES_JUEGO - riskFactor + manoBias // Umbral para cortar por pares
+        val juegoCutThreshold = MUS_CUT_PARES_JUEGO - riskFactor + manoBias
+        val grandeCutThreshold = MUS_CUT_GRANDE_CHICA - riskFactor + manoBias
+        val chicaCutThreshold = MUS_CUT_GRANDE_CHICA - riskFactor + manoBias
 
         if (strength.pares >= paresCutThreshold) return Pair(GameAction.NoMus, "Reason: Pares strength ${strength.pares} >= threshold $paresCutThreshold (manoBias $manoBias)")
         if (strength.juego >= juegoCutThreshold) return Pair(GameAction.NoMus, "Reason: Juego strength ${strength.juego} >= threshold $juegoCutThreshold (manoBias $manoBias)")
@@ -492,13 +486,13 @@ class AILogic constructor(
     }
 
     /**
-     * Override de corte por capitanía delegada (#20). Si actúo antes que mi
-     * compañero le delego el corte; devuelve la decisión o null si no aplica
-     * (entonces decideMus sigue con los umbrales, con delegationBias si toca).
-     * - Capitán humano: delegación dura (no corto, ve mi seña y decide él);
-     *   estrategia mixta: a veces con jugada buena corto, para no cantar el
-     *   patrón "el primero nunca corta".
-     * - Capitán IA: la nuts la corto yo igual (válvula EV).
+     * Override de corte por capitanía delegada (#20). Solo actúa si actúo
+     * ANTES que mi compañero y este es HUMANO: le delego el corte (no corto,
+     * verá mi seña —piezas B/C— y decide él). Estrategia mixta: a veces con
+     * jugada buena corto igual, para no cantar el patrón "el primero nunca
+     * corta". Con compañero IA devuelve null (no-op: el simulador probó que
+     * delegar IA->IA sangra sin beneficio; ver constantes #20). null =
+     * decideMus sigue con sus umbrales de siempre.
      *
      * TODO #17 (mus corrido): en master no existe ese modo, pero al mergearlo
      * esta delegación DEBE quedar deshabilitada — el mus corrido prohíbe señas
@@ -509,19 +503,13 @@ class AILogic constructor(
         partnerIsAi: Boolean,
         bestStrength: Int
     ): Pair<GameAction, String>? {
-        if (!iActBeforePartner) return null
-        return if (!partnerIsAi) {
-            val breakIt = bestStrength >= MUS_DELEGATION_BREAK_FLOOR &&
-                rng.nextInt(100) < MUS_DELEGATION_BREAK_PCT
-            if (breakIt) {
-                GameAction.NoMus to "Reason: #20 delegación rota (jugada $bestStrength); capitán humano"
-            } else {
-                GameAction.Mus to "Reason: #20 delego el corte al capitán humano"
-            }
-        } else if (bestStrength >= MUS_NUTS_FLOOR) {
-            GameAction.NoMus to "Reason: #20 nuts $bestStrength >= $MUS_NUTS_FLOOR; corto pese a delegar"
+        if (!iActBeforePartner || partnerIsAi) return null
+        val breakIt = bestStrength >= MUS_DELEGATION_BREAK_FLOOR &&
+            rng.nextInt(100) < MUS_DELEGATION_BREAK_PCT
+        return if (breakIt) {
+            GameAction.NoMus to "Reason: #20 delegación rota (jugada $bestStrength); capitán humano"
         } else {
-            null
+            GameAction.Mus to "Reason: #20 delego el corte al capitán humano"
         }
     }
 

--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -36,6 +36,19 @@ private const val MUS_CUT_PARES_JUEGO = 75
 private const val MUS_CUT_GRANDE_CHICA = 85
 // Si el COMPAÑERO es mano, sube el listón de corte (no quitarle la mano).
 private const val PARTNER_MANO_MUS_BIAS = 10
+// #20 Capitanía delegada de Mus: si actúo ANTES que mi compañero, le delego
+// el corte (es el capitán). Sesgo a pedir Mus subiendo el umbral de corte.
+private const val MUS_DELEGATION_BIAS = 8
+// Capitán = IA: las manos premium (nuts) las corto yo igualmente, no se
+// delegan (válvula EV: delegar la nuts y que el capitán dé Mus tira un
+// ganador). No aplica si el capitán es humano (su experiencia prima).
+private const val MUS_NUTS_FLOOR = 90
+// Capitán = humano: delegación dura (no corto), PERO estrategia mixta
+// anti-lectura: de vez en cuando, con jugada buena, corto igual para que el
+// rival no cante el patrón "el primero nunca corta". % y suelo provisionales,
+// a afinar con simulador/playtest (no fijar a ojo).
+private const val MUS_DELEGATION_BREAK_PCT = 12
+private const val MUS_DELEGATION_BREAK_FLOOR = 70
 // Apertura de envite por bandas: > fuerte = valor seguro; [piso..fuerte] =
 // banda media probabilística; < piso = solo farol de robo.
 private const val OPEN_STRONG_VALUE = 78
@@ -434,10 +447,23 @@ class AILogic constructor(
         val partnerIsMano = partner != null && gameState.manoPlayerId == partner.id
         val manoBias = if (partnerIsMano) PARTNER_MANO_MUS_BIAS else 0
 
-        val paresCutThreshold = MUS_CUT_PARES_JUEGO - riskFactor + manoBias // Umbral para cortar por pares
-        val juegoCutThreshold = MUS_CUT_PARES_JUEGO - riskFactor + manoBias
-        val grandeCutThreshold = MUS_CUT_GRANDE_CHICA - riskFactor + manoBias
-        val chicaCutThreshold = MUS_CUT_GRANDE_CHICA - riskFactor + manoBias
+        // Capitanía delegada (#20): el corte del Mus lo lidera el CAPITÁN (el
+        // que actúa DESPUÉS). Si actúo ANTES, le delego el corte. El override
+        // resuelve los casos de delegación; null = seguir con los umbrales.
+        val iActBeforePartner = actsBeforePartner(gameState, aiPlayer, partner)
+        val partnerIsAi = partner?.isAi == true
+        val bestStrength = maxOf(strength.pares, strength.juego, strength.grande, strength.chica)
+        decideMusDelegation(iActBeforePartner, partnerIsAi, bestStrength)?.let { return it }
+
+        // Capitán-IA con mano no-premium: delego la banda media subiendo el
+        // umbral. Si soy el capitán (actúo después) bias = 0 -> lógica de
+        // siempre (comportamiento-cero para el capitán).
+        val delegationBias = if (iActBeforePartner) MUS_DELEGATION_BIAS else 0
+
+        val paresCutThreshold = MUS_CUT_PARES_JUEGO - riskFactor + manoBias + delegationBias
+        val juegoCutThreshold = MUS_CUT_PARES_JUEGO - riskFactor + manoBias + delegationBias
+        val grandeCutThreshold = MUS_CUT_GRANDE_CHICA - riskFactor + manoBias + delegationBias
+        val chicaCutThreshold = MUS_CUT_GRANDE_CHICA - riskFactor + manoBias + delegationBias
 
         if (strength.pares >= paresCutThreshold) return Pair(GameAction.NoMus, "Reason: Pares strength ${strength.pares} >= threshold $paresCutThreshold (manoBias $manoBias)")
         if (strength.juego >= juegoCutThreshold) return Pair(GameAction.NoMus, "Reason: Juego strength ${strength.juego} >= threshold $juegoCutThreshold (manoBias $manoBias)")
@@ -450,6 +476,53 @@ class AILogic constructor(
             "Reason: No strength exceeds thresholds to cut mus"
         }
         return Pair(GameAction.Mus, musReason)
+    }
+
+    /** ¿Actúo ANTES que mi compañero en el turno? (capitán = el de después). */
+    private fun actsBeforePartner(
+        gameState: GameState,
+        aiPlayer: Player,
+        partner: Player?
+    ): Boolean {
+        partner ?: return false
+        val order = gameLogic.getTurnOrderedPlayers(gameState.players, gameState.manoPlayerId)
+        val myPos = order.indexOfFirst { it.id == aiPlayer.id }
+        val partnerPos = order.indexOfFirst { it.id == partner.id }
+        return myPos >= 0 && partnerPos >= 0 && myPos < partnerPos
+    }
+
+    /**
+     * Override de corte por capitanía delegada (#20). Si actúo antes que mi
+     * compañero le delego el corte; devuelve la decisión o null si no aplica
+     * (entonces decideMus sigue con los umbrales, con delegationBias si toca).
+     * - Capitán humano: delegación dura (no corto, ve mi seña y decide él);
+     *   estrategia mixta: a veces con jugada buena corto, para no cantar el
+     *   patrón "el primero nunca corta".
+     * - Capitán IA: la nuts la corto yo igual (válvula EV).
+     *
+     * TODO #17 (mus corrido): en master no existe ese modo, pero al mergearlo
+     * esta delegación DEBE quedar deshabilitada — el mus corrido prohíbe señas
+     * y exige decisión de corte individual (determina la mano).
+     */
+    private fun decideMusDelegation(
+        iActBeforePartner: Boolean,
+        partnerIsAi: Boolean,
+        bestStrength: Int
+    ): Pair<GameAction, String>? {
+        if (!iActBeforePartner) return null
+        return if (!partnerIsAi) {
+            val breakIt = bestStrength >= MUS_DELEGATION_BREAK_FLOOR &&
+                rng.nextInt(100) < MUS_DELEGATION_BREAK_PCT
+            if (breakIt) {
+                GameAction.NoMus to "Reason: #20 delegación rota (jugada $bestStrength); capitán humano"
+            } else {
+                GameAction.Mus to "Reason: #20 delego el corte al capitán humano"
+            }
+        } else if (bestStrength >= MUS_NUTS_FLOOR) {
+            GameAction.NoMus to "Reason: #20 nuts $bestStrength >= $MUS_NUTS_FLOOR; corto pese a delegar"
+        } else {
+            null
+        }
     }
 
 

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
@@ -16,6 +16,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
+// #20 (pieza C): tiempo que la seña permanece visible en pantalla. 1.5 s para
+// que un HUMANO pueda leerla (antes 300 ms, ilegible). No afecta a la IA ni a
+// la interceptación rival (opponentSignPerceived no usa la duración visual).
+private const val GESTURE_VISIBLE_MS = 1500L
 
 class GameViewModel constructor(
     internal val gameLogic: MusGameLogic,
@@ -158,10 +162,10 @@ class GameViewModel constructor(
                 )
 
                 // --- TEMPORIZADOR PARA LA PARTE VISUAL ---
-                // La seña visual desaparecerá después de 1.5 segundos,
-                // pero la IA la seguirá recordando en 'knownGestures'.
+                // #20 (pieza C): visible GESTURE_VISIBLE_MS para que un HUMANO
+                // pueda leerla; la IA la recuerda en 'knownGestures' aparte.
                 viewModelScope.launch {
-                    delay(300)
+                    delay(GESTURE_VISIBLE_MS)
                     // Solo borra la seña si sigue siendo la misma que se activó
                     if (_gameState.value.activeGesture == newGesture) {
                         _gameState.value = _gameState.value.copy(activeGesture = null)
@@ -535,32 +539,39 @@ class GameViewModel constructor(
 
     private fun triggerAiGestures() {
         viewModelScope.launch {
-            val currentState = _gameState.value
-
-            // --- INICIO DE LA CORRECCIÓN ---
-            // Ahora seleccionamos a las IAs cuyo compañero TAMBIÉN es una IA.
-            val aiPlayersWithAiPartners = currentState.players.filter { aiPlayer ->
-                aiPlayer.isAi && currentState.players.any { partner ->
-                    partner.id != aiPlayer.id && partner.team == aiPlayer.team && partner.isAi
-                }
-            }
-            // --- FIN DE LA CORRECCIÓN ---
-
             // Esperamos un poco para que no sea instantáneo
             delay(2000)
             awaitNotPaused()
 
-            // El resto de la función itera sobre la nueva lista
-            for (aiPlayer in aiPlayersWithAiPartners) {
-                // 70% de probabilidad de que la IA decida pasar una seña
-                if (kotlin.random.Random.nextFloat() < 0.70f) {
-                    val gestureResId = determineGesture(aiPlayer)
-                    if (gestureResId != null) {
-                        onAction(GameAction.ShowGesture, aiPlayer.id)
-                        // Pequeña pausa por si varias IAs quisieran pasar seña
-                        delay(500)
-                        awaitNotPaused()
-                    }
+            // #20 (pieza B): la IA emite seña tenga compañero IA o HUMANO. El
+            // capitán humano necesita ver la seña para decidir el corte que el
+            // primero le delega; antes solo se emitía IA->IA y el humano
+            // jugaba a ciegas. La interceptación rival (opponentSignPerceived,
+            // prob 0.20 fija) NO depende de esto, así que no añade exposición.
+            val signalerIds = _gameState.value.players.filter { aiPlayer ->
+                aiPlayer.isAi && _gameState.value.players.any { partner ->
+                    partner.id != aiPlayer.id && partner.team == aiPlayer.team
+                }
+            }.map { it.id }
+
+            for (signalerId in signalerIds) {
+                // La seña solo tiene sentido en MUS; tras los delay la fase o
+                // la mano pueden haber cambiado, así que releemos el estado
+                // fresco (no una copia stale): el humano decidirá su corte con
+                // lo que vea, debe reflejar fase y mano reales.
+                if (_gameState.value.gamePhase != GamePhase.MUS) return@launch
+                val player = _gameState.value.players.find { it.id == signalerId }
+                val willSignal = player != null &&
+                    kotlin.random.Random.nextFloat() < 0.70f &&
+                    determineGesture(player) != null
+                if (willSignal) {
+                    onAction(GameAction.ShowGesture, signalerId)
+                    // Esperar a que la seña agote su ventana visible: si la
+                    // siguiente llegara antes (delay < GESTURE_VISIBLE_MS)
+                    // pisaría a la anterior y se vería solo un flash (el bug
+                    // que la pieza C arregla quedaría sin efecto en cadenas).
+                    delay(GESTURE_VISIBLE_MS)
+                    awaitNotPaused()
                 }
             }
         }

--- a/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/presentation/GameViewModel.kt
@@ -16,10 +16,14 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
-// #20 (pieza C): tiempo que la seña permanece visible en pantalla. 1.5 s para
-// que un HUMANO pueda leerla (antes 300 ms, ilegible). No afecta a la IA ni a
-// la interceptación rival (opponentSignPerceived no usa la duración visual).
-private const val GESTURE_VISIBLE_MS = 1500L
+// #20 (pieza C): visibilidad de la seña en pantalla, ASIMÉTRICA. Solo la del
+// COMPAÑERO del humano dura 1.5 s (para que él la lea y decida el corte que se
+// le delega). La del RIVAL (y la propia) vuelve al flash corto de antes: si
+// durara 1.5 s el humano interceptaría señas rivales gratis, rompiendo el
+// balance (la IA solo intercepta al 20%, opponentSignPerceived). No afecta a
+// la IA ni a esa interceptación (no usan la duración visual).
+private const val GESTURE_VISIBLE_PARTNER_MS = 1500L
+private const val GESTURE_VISIBLE_OTHER_MS = 300L
 
 class GameViewModel constructor(
     internal val gameLogic: MusGameLogic,
@@ -162,10 +166,11 @@ class GameViewModel constructor(
                 )
 
                 // --- TEMPORIZADOR PARA LA PARTE VISUAL ---
-                // #20 (pieza C): visible GESTURE_VISIBLE_MS para que un HUMANO
-                // pueda leerla; la IA la recuerda en 'knownGestures' aparte.
+                // #20 (pieza C): el compañero del humano dura 1.5 s (legible);
+                // rival/propia, flash corto. La IA la recuerda en
+                // 'knownGestures' aparte (no depende de esta duración).
                 viewModelScope.launch {
-                    delay(GESTURE_VISIBLE_MS)
+                    delay(gestureVisibleMs(playerId))
                     // Solo borra la seña si sigue siendo la misma que se activó
                     if (_gameState.value.activeGesture == newGesture) {
                         _gameState.value = _gameState.value.copy(activeGesture = null)
@@ -537,6 +542,21 @@ class GameViewModel constructor(
         return null
     }
 
+    /**
+     * #20 (pieza C): cuánto dura visible en pantalla la seña de [signalerId].
+     * Solo la del COMPAÑERO del humano es legible (1.5 s, para que decida el
+     * corte que se le delega); la del rival y la propia, flash corto, para que
+     * el humano no intercepte señas rivales gratis (la IA solo al 20%).
+     */
+    private fun gestureVisibleMs(signalerId: String): Long {
+        val players = _gameState.value.players
+        val humanTeam = players.find { it.id == humanPlayerId }?.team
+        val signaler = players.find { it.id == signalerId }
+        val isHumanPartner = humanTeam != null && signaler != null &&
+            signaler.id != humanPlayerId && signaler.team == humanTeam
+        return if (isHumanPartner) GESTURE_VISIBLE_PARTNER_MS else GESTURE_VISIBLE_OTHER_MS
+    }
+
     private fun triggerAiGestures() {
         viewModelScope.launch {
             // Esperamos un poco para que no sea instantáneo
@@ -566,11 +586,12 @@ class GameViewModel constructor(
                     determineGesture(player) != null
                 if (willSignal) {
                     onAction(GameAction.ShowGesture, signalerId)
-                    // Esperar a que la seña agote su ventana visible: si la
-                    // siguiente llegara antes (delay < GESTURE_VISIBLE_MS)
-                    // pisaría a la anterior y se vería solo un flash (el bug
-                    // que la pieza C arregla quedaría sin efecto en cadenas).
-                    delay(GESTURE_VISIBLE_MS)
+                    // Esperar a que ESTA seña agote su ventana visible para
+                    // que la siguiente no la pise. Es la duración propia del
+                    // emisor (compañero del humano = 1.5 s; rival = flash), así
+                    // una cadena de señas rivales no retrasa 1.5 s la del
+                    // compañero (era el "tarda un poco" del playtest).
+                    delay(gestureVisibleMs(signalerId))
                     awaitNotPaused()
                 }
             }


### PR DESCRIPTION
Backlog #20. Reportado por el usuario: cuando él es el segundo de su
pareja (capitán), la IA-primero le cortaba el Mus y no le dejaba jugar
esa decisión.

## Qué hace

Si la IA actúa ANTES que su compañero y este es **humano**, le delega
el corte del Mus: pide Mus (no corta) para que el capitán humano decida,
viendo la seña de la IA. Estrategia mixta anti-lectura: ~12% con jugada
buena (≥70) corta igual, para no cantar el patrón "el primero nunca
corta".

Tres piezas:
- **A** `decideMus`: override de delegación solo en la rama compañero-
  humano (extraído a `actsBeforePartner`/`decideMusDelegation`). Con
  compañero IA o siendo capitán → comportamiento-cero.
- **B** `triggerAiGestures`: la IA emite seña tenga compañero IA o
  humano (el capitán humano la necesita para decidir el corte delegado).
  Guarda de fase MUS + relectura de estado fresco + secuenciado a la
  ventana visible (bugs que la ventana de 1.5s destapaba, hallados por
  compose-ui-reviewer).
- **C** seña visible 300ms → 1.5s para que un humano la lea. No afecta
  a IA ni a interceptación rival (desacoplada).

## Por qué solo compañero humano

El simulador IA↔IA (200 partidas, seed fijo, A/B vs master) probó que
delegar cuando el capitán es IA sangra "aceptar" tantos netos a
cualquier magnitud (bias +8 → −317, +3 → −285, 0 → −113 = baseline
−115), sin beneficio: la seña sub-transporta la fuerza de corte
(`partnerGrandeBoost(reyes_2)=65` < umbral 85), el capitán IA no
recupera el corte → redeal → se juega/acepta peor. No existe delegación
IA↔IA EV-neutra con valor (confirmado con mus-strategy-reviewer). El
valor de #20 es solo la experiencia del humano-capitán.

## Verificación

- Diseñado/iterado con **mus-strategy-reviewer** (3 rondas + el pivote
  por datos del simulador). Legalidad OK por **mus-rules-reviewer** (sin
  mus corrido en master; TODO #17 anotado). Timing UI por
  **compose-ui-reviewer** (2 bugs arreglados en el PR).
- Simulador A/B: gate (aceptar neto ≥ baseline) **verde por
  construcción** — con compañero IA es no-op exacto (medido: bias 0 →
  −113 ≈ baseline; snapshot 0b byte-idéntico).
- Goldens 0a/0b byte-idénticos, 55 tests + ambas variantes + detekt
  verdes.

## Pendiente (bloquea merge)

La rama compañero-humano **no la mide el simulador** (es IA↔IA).
Requiere **playtest del usuario**: con él de capitán (actúa después que
su compañero IA), verificar que (1) la IA-primero le delega el corte y
no se lo quita, (2) ve la seña del compañero IA a 1.5s y decide, (3) la
ruptura ~12% no se percibe como robótica. Los % `MUS_DELEGATION_BREAK_
PCT=12`/`FLOOR=70` son provisionales, solo afinables por ese playtest.