### PR TITLE
fix(ai): #14 partnerGrandeBoost(sena_31) 70 -> 35

### DIFF
--- a/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
+++ b/app/src/main/java/com/doselfurioso/musvisto/logic/AILogic.kt
@@ -1200,7 +1200,7 @@ class AILogic constructor(
     // que podrían rebajar la jugada real para Grande.
     internal fun partnerGrandeBoost(gestureResId: Int): Int = when (gestureResId) {
         R.drawable.reyes_3 -> 90   // 3 Reyes/Treses → dispara Envido seguro (>80)
-        R.drawable.sena_31 -> 70   // 31 implica figuras pero no necesariamente Reyes
+        R.drawable.sena_31 -> 35   // #14: 31 da figuras pero 0-1 Reyes modal; señal Grande débil
         R.drawable.reyes_2 -> 65   // par alto: activa bluff y empuja a Envido si ya tienes algo
         R.drawable.duples_altos -> 78  // #23: 2 reyes garantizados sin riesgo de descarte; entre reyes_2 y reyes_3
         else -> 0

--- a/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
+++ b/app/src/test/java/com/doselfurioso/musvisto/logic/AILogicTest.kt
@@ -515,8 +515,10 @@ class AILogicTest {
     }
 
     @Test
-    fun `partnerGrandeBoost - sena_31 implies figures, gets moderate boost`() {
-        assertEquals(70, aiLogic.partnerGrandeBoost(com.doselfurioso.musvisto.R.drawable.sena_31))
+    fun `partnerGrandeBoost - sena_31 weak Grande signal (0-1 reyes modal), low boost`() {
+        // #14: bajado 70 -> 35; un 31 no implica Reyes, queda por debajo de
+        // reyes_2=65 (par confirmado) y del umbral de apoyo de Grande.
+        assertEquals(35, aiLogic.partnerGrandeBoost(com.doselfurioso.musvisto.R.drawable.sena_31))
     }
 
     @Test


### PR DESCRIPTION
Backlog #14. Un 31 de Juego da figuras pero 0-1 Reyes es lo modal: como
señal de **Grande** es débil. A 70 valía MÁS que un par de Reyes
confirmado (`reyes_2=65`) y, al ser ≥65, una seña de 31 del compañero
disparaba rol de APOYO de Grande (`shouldPlaySupport` L422) — capitanía
pisada por inferencia espuria. Bug estructural de tabla, no preferencia
tuneable.

## Cambio
`partnerGrandeBoost(sena_31)` 70 → **35** (una línea, `AILogic.kt:1203`).
Sirve a los 3 usos: merge ofensivo (L1100, deja de inflar Grande de
equipo por una señal de Juego), defensa #9 (L1181, la IA deja de aflojar
Grande de forma explotable ante un 31 rival) y deja de disparar apoyo de
Grande (L422, 35 < 65). Test unitario actualizado (`AILogicTest.kt:521`).

## Verificación
- Magnitud fijada por **mus-strategy-reviewer** (35, razonamiento EV:
  31 es señal de Juego, no de Grande; debe quedar muy por debajo de un
  par de Reyes confirmado).
- **Gate del simulador declarado NO concluyente** para #14 (patrón
  #28/#12): el A/B IA↔IA da una curva caótica determinista NO monótona
  (70→−115, 60→−68, 55→−91, 50→−219, 35→−162); no hay gradiente EV, el
  sim es parcialmente ciego al eje defensivo. NO se rechaza por el −47
  de 35 ni se premia el +47 de 60 (sería overfitting al seed,
  antipatrón feedback_ai_tuning). El cambio se justifica por
  corrección estructural + EV teórico, no por la métrica.
- Snapshot 0b byte-idéntico (no afecta a las 161 decisiones
  muestreadas), ambas variantes + 55 tests + detekt verdes.

## Validación pendiente (playtest-bound, el sim no sirve aquí)
Que la IA: (1) no abra/suba Grande solo porque el compañero señaló 31;
(2) no afloje Grande de forma explotable ante un 31 rival; (3) no ceda
apoyo de Grande por un 31 del compañero.